### PR TITLE
feat: implement MCP Standard 2025-06-18 simple compliance changes

### DIFF
--- a/internal/json/writer.go
+++ b/internal/json/writer.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/dgellow/mcp-front/internal"
@@ -45,6 +46,17 @@ func WriteError(w http.ResponseWriter, statusCode int, error string, message str
 
 // Common error responses
 func WriteUnauthorized(w http.ResponseWriter, message string) {
+	WriteError(w, http.StatusUnauthorized, "unauthorized", message)
+}
+
+// WriteUnauthorizedWithChallenge writes a 401 Unauthorized response with WWW-Authenticate header
+// This is used for MCP Standard 2025-06-18 compliance
+func WriteUnauthorizedWithChallenge(w http.ResponseWriter, message string, realm string, resourceMetadataURI string) {
+	if resourceMetadataURI != "" && realm != "" {
+		// Format: Bearer realm="example", as_uri="https://example.com/.well-known/oauth-protected-resource"
+		challenge := fmt.Sprintf(`Bearer realm="%s", as_uri="%s"`, realm, resourceMetadataURI)
+		w.Header().Set("WWW-Authenticate", challenge)
+	}
 	WriteError(w, http.StatusUnauthorized, "unauthorized", message)
 }
 

--- a/internal/json/writer_test.go
+++ b/internal/json/writer_test.go
@@ -1,0 +1,81 @@
+package json
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteUnauthorizedWithChallenge(t *testing.T) {
+	tests := []struct {
+		name                string
+		message             string
+		realm               string
+		resourceMetadataURI string
+		wantHeader          string
+		wantStatus          int
+	}{
+		{
+			name:                "with resource metadata URI and realm",
+			message:             "Invalid token",
+			realm:               "TestProxy",
+			resourceMetadataURI: "https://example.com/.well-known/oauth-protected-resource",
+			wantHeader:          `Bearer realm="TestProxy", as_uri="https://example.com/.well-known/oauth-protected-resource"`,
+			wantStatus:          http.StatusUnauthorized,
+		},
+		{
+			name:                "without resource metadata URI",
+			message:             "Invalid token",
+			realm:               "TestProxy",
+			resourceMetadataURI: "",
+			wantHeader:          "",
+			wantStatus:          http.StatusUnauthorized,
+		},
+		{
+			name:                "without realm",
+			message:             "Invalid token",
+			realm:               "",
+			resourceMetadataURI: "https://example.com/.well-known/oauth-protected-resource",
+			wantHeader:          "",
+			wantStatus:          http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			
+			WriteUnauthorizedWithChallenge(w, tt.message, tt.realm, tt.resourceMetadataURI)
+			
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %v, want %v", w.Code, tt.wantStatus)
+			}
+			
+			gotHeader := w.Header().Get("WWW-Authenticate")
+			if gotHeader != tt.wantHeader {
+				t.Errorf("WWW-Authenticate header = %q, want %q", gotHeader, tt.wantHeader)
+			}
+			
+			// Check that response contains error message
+			body := w.Body.String()
+			if body == "" {
+				t.Error("expected non-empty response body")
+			}
+		})
+	}
+}
+
+func TestWriteUnauthorized(t *testing.T) {
+	w := httptest.NewRecorder()
+	
+	WriteUnauthorized(w, "Test error")
+	
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %v, want %v", w.Code, http.StatusUnauthorized)
+	}
+	
+	// Should not have WWW-Authenticate header
+	if header := w.Header().Get("WWW-Authenticate"); header != "" {
+		t.Errorf("unexpected WWW-Authenticate header: %q", header)
+	}
+}

--- a/internal/oauth/metadata.go
+++ b/internal/oauth/metadata.go
@@ -1,0 +1,33 @@
+package oauth
+
+import (
+	"net/http"
+
+	"github.com/dgellow/mcp-front/internal"
+	jsonwriter "github.com/dgellow/mcp-front/internal/json"
+	"github.com/dgellow/mcp-front/internal/urlutil"
+)
+
+// ProtectedResourceMetadataHandler serves OAuth 2.0 Protected Resource Metadata (RFC 9728)
+// This endpoint helps clients discover which authorization servers this resource server trusts
+func (s *Server) ProtectedResourceMetadataHandler(w http.ResponseWriter, r *http.Request) {
+	// Build the metadata response
+	metadata := map[string]interface{}{
+		"resource": s.config.Issuer, // The canonical URI of this resource server
+		"authorization_servers": []string{
+			s.config.Issuer, // We are our own authorization server
+		},
+		"_links": map[string]interface{}{
+			"oauth-authorization-server": map[string]string{
+				"href": urlutil.MustJoinPath(s.config.Issuer, ".well-known", "oauth-authorization-server"),
+			},
+		},
+	}
+
+	// Write the response
+	if err := jsonwriter.Write(w, metadata); err != nil {
+		internal.LogErrorWithFields("oauth", "Failed to encode protected resource metadata", map[string]interface{}{
+			"error": err.Error(),
+		})
+	}
+}

--- a/internal/oauth/metadata_test.go
+++ b/internal/oauth/metadata_test.go
@@ -1,0 +1,68 @@
+package oauth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dgellow/mcp-front/internal/storage"
+)
+
+func TestProtectedResourceMetadataHandler(t *testing.T) {
+	// Create a test server
+	config := Config{
+		Issuer:        "https://example.com",
+		ProxyName:     "test-proxy",
+		EncryptionKey: "test-encryption-key-32-bytes----", // Exactly 32 bytes for AES-256
+		JWTSecret:     "test-jwt-secret-at-least-32-bytes-long",
+	}
+	
+	store := storage.NewMemoryStorage()
+	server, err := NewServer(config, store)
+	if err != nil {
+		t.Fatalf("Failed to create OAuth server: %v", err)
+	}
+
+	// Create test request
+	req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource", nil)
+	w := httptest.NewRecorder()
+
+	// Call the handler
+	server.ProtectedResourceMetadataHandler(w, req)
+
+	// Check response
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %v, want %v", w.Code, http.StatusOK)
+	}
+
+	// Parse response
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &metadata); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	// Check required fields
+	if resource, ok := metadata["resource"].(string); !ok || resource != "https://example.com" {
+		t.Errorf("resource = %v, want %v", metadata["resource"], "https://example.com")
+	}
+
+	if authServers, ok := metadata["authorization_servers"].([]interface{}); !ok || len(authServers) != 1 {
+		t.Errorf("authorization_servers = %v, want array with 1 element", metadata["authorization_servers"])
+	} else if authServers[0] != "https://example.com" {
+		t.Errorf("authorization_servers[0] = %v, want %v", authServers[0], "https://example.com")
+	}
+
+	// Check _links
+	if links, ok := metadata["_links"].(map[string]interface{}); !ok {
+		t.Error("_links field missing or not an object")
+	} else {
+		if authServerLink, ok := links["oauth-authorization-server"].(map[string]interface{}); !ok {
+			t.Error("oauth-authorization-server link missing")
+		} else {
+			if href, ok := authServerLink["href"].(string); !ok || href != "https://example.com/.well-known/oauth-authorization-server" {
+				t.Errorf("oauth-authorization-server href = %v, want %v", href, "https://example.com/.well-known/oauth-authorization-server")
+			}
+		}
+	}
+}

--- a/internal/urlutil/join.go
+++ b/internal/urlutil/join.go
@@ -1,0 +1,35 @@
+package urlutil
+
+import (
+	"net/url"
+	"path"
+	"strings"
+)
+
+// JoinPath safely joins URL paths, handling trailing and leading slashes correctly
+func JoinPath(base string, paths ...string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+
+	// Join paths, ensuring proper slash handling
+	allPaths := append([]string{u.Path}, paths...)
+	u.Path = path.Join(allPaths...)
+	
+	// Preserve trailing slash if the last path component had one
+	if len(paths) > 0 && strings.HasSuffix(paths[len(paths)-1], "/") {
+		u.Path += "/"
+	}
+
+	return u.String(), nil
+}
+
+// MustJoinPath is like JoinPath but panics on error (for use with known-good URLs)
+func MustJoinPath(base string, paths ...string) string {
+	result, err := JoinPath(base, paths...)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}

--- a/internal/urlutil/join_test.go
+++ b/internal/urlutil/join_test.go
@@ -1,0 +1,87 @@
+package urlutil
+
+import (
+	"testing"
+)
+
+func TestJoinPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    string
+		paths   []string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "simple join",
+			base:  "https://example.com",
+			paths: []string{"api", "v1"},
+			want:  "https://example.com/api/v1",
+		},
+		{
+			name:  "base with path",
+			base:  "https://example.com/base",
+			paths: []string{"api", "v1"},
+			want:  "https://example.com/base/api/v1",
+		},
+		{
+			name:  "trailing slash preserved",
+			base:  "https://example.com",
+			paths: []string{"api", "v1/"},
+			want:  "https://example.com/api/v1/",
+		},
+		{
+			name:  "well-known path",
+			base:  "https://example.com",
+			paths: []string{".well-known", "oauth-protected-resource"},
+			want:  "https://example.com/.well-known/oauth-protected-resource",
+		},
+		{
+			name:  "empty paths",
+			base:  "https://example.com",
+			paths: []string{},
+			want:  "https://example.com",
+		},
+		{
+			name:  "base with trailing slash",
+			base:  "https://example.com/",
+			paths: []string{"api"},
+			want:  "https://example.com/api",
+		},
+		{
+			name:    "invalid base URL",
+			base:    "://invalid",
+			paths:   []string{"api"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := JoinPath(tt.base, tt.paths...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JoinPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("JoinPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMustJoinPath(t *testing.T) {
+	// Test normal operation
+	result := MustJoinPath("https://example.com", "api", "v1")
+	if result != "https://example.com/api/v1" {
+		t.Errorf("MustJoinPath() = %v, want %v", result, "https://example.com/api/v1")
+	}
+
+	// Test panic on invalid URL
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("MustJoinPath() should have panicked")
+		}
+	}()
+	MustJoinPath("://invalid", "api")
+}


### PR DESCRIPTION
- Add WWW-Authenticate headers to 401 responses with configurable realm
- Add OAuth Protected Resource Metadata endpoint at /.well-known/oauth-protected-resource
- Use proxy name from config as realm instead of hardcoded value
- Add urlutil package for proper URL path joining
- Include comprehensive tests for all new functionality

No breaking changes - fully backward compatible with existing clients.

🤖 Generated with [Claude Code](https://claude.ai/code)