### PR TITLE
Add annoying workaround

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -216,6 +216,11 @@ type OAuthAuthConfig struct {
 	GoogleRedirectURI   string        `json:"googleRedirectUri"`
 	JWTSecret           Secret        `json:"jwtSecret"`
 	EncryptionKey       Secret        `json:"encryptionKey"`
+	// DangerouslyAcceptIssuerAudience allows tokens with just the base issuer as audience
+	// to be accepted for any service. This is a workaround for MCP clients that don't
+	// properly implement RFC 8707 resource indicators, but it defeats per-service token
+	// isolation. Only enable this if you understand the security implications.
+	DangerouslyAcceptIssuerAudience bool `json:"dangerouslyAcceptIssuerAudience,omitempty"`
 }
 
 // ProxyConfig represents the proxy configuration with resolved values


### PR DESCRIPTION
Workaround for MCP clients (like Claude Code) that don't properly implement RFC 8707 resource indicators. When enabled, tokens with just the base issuer as audience are accepted for any service.