### PR TITLE
Fix session lifecycle bugs and add tests

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -328,7 +328,7 @@ func NewBrowserSSOMiddleware(authConfig config.OAuthAuthConfig, idpProvider idp.
 			}
 
 			// Check expiration
-			if time.Now().After(sessionData.Expires) {
+			if sessionData.IsExpired() {
 				log.LogDebug("Session expired for user %s", sessionData.Email)
 				cookie.ClearSession(w)
 				// Redirect directly to OAuth

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -8,6 +8,10 @@ type BrowserCookie struct {
 	Expires  time.Time `json:"expires"`
 }
 
+func (c BrowserCookie) IsExpired() bool {
+	return time.Now().After(c.Expires)
+}
+
 type AuthorizationState struct {
 	Nonce     string `json:"nonce"`
 	ReturnURL string `json:"return_url"`

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -28,14 +28,14 @@ func TestBrowserCookie_MarshalUnmarshal(t *testing.T) {
 	assert.WithinDuration(t, original.Expires, unmarshaled.Expires, time.Second)
 }
 
-func TestBrowserCookie_Expiry(t *testing.T) {
+func TestBrowserCookie_IsExpired(t *testing.T) {
 	t.Run("not expired", func(t *testing.T) {
 		s := BrowserCookie{
 			Email:    "user@example.com",
 			Provider: "google",
 			Expires:  time.Now().Add(1 * time.Hour),
 		}
-		assert.True(t, s.Expires.After(time.Now()))
+		assert.False(t, s.IsExpired())
 	})
 
 	t.Run("expired", func(t *testing.T) {
@@ -44,7 +44,7 @@ func TestBrowserCookie_Expiry(t *testing.T) {
 			Provider: "google",
 			Expires:  time.Now().Add(-1 * time.Hour),
 		}
-		assert.True(t, s.Expires.Before(time.Now()))
+		assert.True(t, s.IsExpired())
 	})
 }
 


### PR DESCRIPTION
DeleteUser now cascades to session cleanup in both memory and Firestore backends, and the admin handler terminates live stdio sessions before deletion. Firestore TrackSession and UpsertUser no longer do racy read-before-write — TrackSession uses a simple Set, UpsertUser uses a transaction. Memory TrackSession respects caller-provided Created timestamps. Admin dashboard filters stale sessions. BrowserCookie gets an IsExpired() method used by middleware.