### PR TITLE
Add aggregate server type

### DIFF
--- a/docs/aggregated-mcp-endpoint.md
+++ b/docs/aggregated-mcp-endpoint.md
@@ -1,0 +1,142 @@
+# Aggregated MCP Endpoint
+
+## Motivation
+
+mcp-front was built as a transparent auth proxy — it sits in front of MCP servers, handles OAuth, and forwards connections. Each backend gets its own endpoint (`/postgres/`, `/linear/`, `/gong/`), its own OAuth token with per-service audience, and its own SSE connection from the client.
+
+This design is correct from a security perspective (per-service token isolation, RFC 8707 compliance) but the main user feedback over the past ~6 months has been about the authentication experience: every service requires a separate login flow. When all your internal MCP servers share the same Google Workspace identity, authenticating 8 times to prove you're the same person is painful. When Claude drops your session, you re-authenticate 8 times again. When Codex spams warnings about unauthenticated MCPs at the start of every session, it's 8 warnings. The friction scales linearly with the number of services, and we keep adding services.
+
+The MCP protocol doesn't have a concept of "these N servers share an identity provider, just auth once." Each MCP server is independent. There's no way to communicate this to the client.
+
+The only reliable way to solve this is to stop exposing N separate MCP servers and instead expose one. Group all backends into a single MCP server, expose it as a single endpoint, and do the routing internally. One connection, one token, all tools.
+
+This is a meaningful shift from the "transparent auth proxy" design toward mcp-front being an actual MCP server that happens to delegate to backends. The building blocks are already there — mcp-front already speaks the MCP protocol as a client to stdio backends, manages sessions, handles tool discovery, and injects user tokens. The aggregated endpoint composes these into a single surface.
+
+## Configuration
+
+Each server in `mcpServers` has a `type` field: `"direct"` (default) or `"aggregate"`. Direct servers proxy to a single backend. Aggregate servers combine multiple backends into one MCP endpoint. The aggregate type is opt-in — you only get it if you add it to your config.
+
+Minimal config — aggregate all servers with defaults:
+
+```json
+{
+  "mcpServers": {
+    "postgres": { "transportType": "stdio", "command": "postgres-mcp" },
+    "linear": { "transportType": "sse", "url": "http://localhost:9000/sse" },
+    "all-tools": {
+      "type": "aggregate"
+    }
+  }
+}
+```
+
+The server name determines the path — `all-tools` gets mounted at `/all-tools/`, same as every other server.
+
+Defaults:
+
+- `servers`: all non-aggregate servers
+- `discovery.timeout`: `"10s"` — return whatever tools have been collected after this deadline
+- `discovery.cacheTtl`: `"60s"` — per-user tool cache lifetime
+
+Fully configured:
+
+```json
+{
+  "mcpServers": {
+    "postgres": { "transportType": "stdio", "command": "postgres-mcp" },
+    "linear": { "transportType": "sse", "url": "http://localhost:9000/sse" },
+    "gong": { "transportType": "stdio", "command": "gong-mcp" },
+    "dev-tools": {
+      "type": "aggregate",
+      "servers": ["postgres", "linear"],
+      "discovery": {
+        "timeout": "15s",
+        "cacheTtl": "2m"
+      },
+      "options": {
+        "toolFilter": {
+          "mode": "block",
+          "list": ["postgres.drop_table"]
+        }
+      },
+      "serviceAuths": [
+        {
+          "type": "bearer",
+          "tokens": ["dev-token-123"]
+        }
+      ]
+    }
+  }
+}
+```
+
+Fields that don't apply to aggregates: `command`, `args`, `env`, `url`, `headers`, `timeout`, `requiresUserToken`, `userAuthentication`, `inline`. Validation rejects them if present on an aggregate.
+
+Validation rejects self-references, references to other aggregate servers, references to nonexistent servers, and server names containing `.`.
+
+## Design
+
+### How it works
+
+The aggregate server acts as an MCP server to the client and an MCP client to every backend it includes. The client connects once, sends `tools/list`, and gets back every tool from every backend. Tool names are prefixed with their service name (`postgres.query`, `linear.create_issue`) so routing is unambiguous. When the client calls `tools/call` with `postgres.query`, the aggregate strips the prefix, routes to the postgres backend, and returns the result.
+
+### Connection lifecycle
+
+1. Client opens SSE, receives a message endpoint URL
+2. Client sends `initialize` — aggregate responds with MCP capabilities
+3. Client sends `tools/list` — aggregate fans out to all backends in parallel, collects and namespaces tools, returns unified list
+4. Client sends `tools/call` with `linear.create_issue` — aggregate parses the prefix, routes to linear backend, returns result
+
+### Tool namespacing
+
+```
+Backend "postgres" tools:  query, list_tables, describe
+Backend "linear" tools:    create_issue, list_issues
+
+Aggregated response:
+  postgres.query
+  postgres.list_tables
+  postgres.describe
+  linear.create_issue
+  linear.list_issues
+```
+
+The `.` separator splits on first occurrence from the left, so tool names containing `.` are preserved — `postgres` + `api.v2.call` becomes `postgres.api.v2.call`, which parses back to `postgres` + `api.v2.call`. Server names cannot contain `.`, which is validated at config load time.
+
+### Per-user backend sessions
+
+Each authenticated user gets their own set of backend MCP client connections. When `user@company.com` connects, the aggregate lazily creates connections to each backend, applying that user's tokens where needed. Connections are cached and reused across tool calls.
+
+User A's tokens are never mixed with user B's.
+
+### Discovery
+
+Tool discovery fans out to all backends in parallel. After `discovery.timeout` (default 10s), the aggregate returns whatever tools have been collected. Backends that haven't responded are skipped — healthy backends aren't held hostage by broken ones.
+
+Results are cached globally for the duration of `discovery.cacheTtl` (default 60s). When the SSE connection first opens, discovery starts immediately in the background so `tools/list` is fast.
+
+### User tokens
+
+For backends that require per-user tokens (API keys, OAuth tokens to upstream services), the existing `UserTokenService` handles retrieval and refresh. If a user hasn't set up their token for a particular service, that service's tools still appear in the aggregated list — but calling them returns a structured error with setup instructions pointing to `/my/tokens`. Same behavior as per-service endpoints today.
+
+### Authentication
+
+The aggregate endpoint uses the same middleware stack as everything else: CORS, OAuth token validation, recovery. Audience validation works naturally — `ValidateTokenMiddleware` extracts the server name from the request path and checks the token's audience accordingly.
+
+### Tool filtering
+
+Tool filtering works at two levels. Per-backend `toolFilter` config on individual servers is respected during aggregation — if the postgres config blocks `drop_table`, it won't appear in the aggregated list. A `toolFilter` on the aggregate server itself filters the final namespaced tool list.
+
+## What stays the same
+
+Per-service endpoints (`/postgres/`, `/linear/`, etc.) continue to work. The aggregate endpoint is additive. Some deployments may prefer per-service connections for token isolation or when a client only needs a single service.
+
+## Scope
+
+**Tools only.** Prompts and resources are not aggregated. Tools are the primary use case, and namespacing resources (which have URI-based identities) is significantly more complex.
+
+**SSE transport.** Uses the SSE + POST message pattern. Streamable HTTP can be added later.
+
+## Future
+
+This is the foundation for tool composition (see `tool-composition-ideas.md`). Once all tools are accessible through a single connection, composed tools that orchestrate across backends can appear alongside them in the same `tools/list` — a unified surface for both raw backend tools and higher-level workflows.

--- a/integration/aggregate_test.go
+++ b/integration/aggregate_test.go
@@ -1,0 +1,226 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregateBasic(t *testing.T) {
+	mcpServers := map[string]any{
+		"test-sse": map[string]any{
+			"transportType": "sse",
+			"url":           "http://localhost:3001/sse",
+		},
+		"test-streamable": map[string]any{
+			"transportType": "streamable-http",
+			"url":           "http://localhost:3002",
+		},
+		"mcp": map[string]any{
+			"type":          "aggregate",
+			"transportType": "sse",
+			"discovery": map[string]any{
+				"timeout":  "10s",
+				"cacheTtl": "60s",
+			},
+		},
+	}
+	cfg := buildTestConfig("http://localhost:8080", "aggregate-test", nil, mcpServers)
+	configPath := writeTestConfig(t, cfg)
+
+	startMCPFront(t, configPath)
+	waitForMCPFront(t)
+
+	client := NewMCPSSEClient("http://localhost:8080")
+	require.NotNil(t, client)
+	defer client.Close()
+
+	t.Run("tool_discovery", func(t *testing.T) {
+		err := client.ConnectToServer("mcp")
+		require.NoError(t, err, "Failed to connect to aggregate endpoint")
+
+		result, err := client.SendMCPRequest("tools/list", map[string]any{})
+		require.NoError(t, err, "Failed to list tools")
+		require.NotContains(t, result, "error")
+
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Expected result field")
+		tools, ok := resultData["tools"].([]any)
+		require.True(t, ok, "Expected tools array")
+
+		toolNames := make(map[string]bool)
+		for _, tool := range tools {
+			toolMap, ok := tool.(map[string]any)
+			if ok {
+				if name, ok := toolMap["name"].(string); ok {
+					toolNames[name] = true
+				}
+			}
+		}
+
+		assert.True(t, toolNames["test-sse.echo_text"], "Missing test-sse.echo_text")
+		assert.True(t, toolNames["test-sse.sample_stream"], "Missing test-sse.sample_stream")
+		assert.True(t, toolNames["test-streamable.get_time"], "Missing test-streamable.get_time")
+		assert.True(t, toolNames["test-streamable.echo_streamable"], "Missing test-streamable.echo_streamable")
+		assert.Equal(t, 4, len(toolNames), "Expected exactly 4 tools, got: %v", toolNames)
+	})
+
+	t.Run("tool_call_sse_backend", func(t *testing.T) {
+		result, err := client.SendMCPRequest("tools/call", map[string]any{
+			"name":      "test-sse.echo_text",
+			"arguments": map[string]any{"text": "hello aggregate"},
+		})
+		require.NoError(t, err, "Failed to call tool")
+
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Expected result field")
+		content, ok := resultData["content"].([]any)
+		require.True(t, ok, "Expected content array")
+		require.NotEmpty(t, content)
+		textContent, ok := content[0].(map[string]any)
+		require.True(t, ok, "Expected text content object")
+		assert.Equal(t, "hello aggregate", textContent["text"])
+	})
+
+	t.Run("tool_call_streamable_backend", func(t *testing.T) {
+		result, err := client.SendMCPRequest("tools/call", map[string]any{
+			"name":      "test-streamable.echo_streamable",
+			"arguments": map[string]any{"text": "world"},
+		})
+		require.NoError(t, err, "Failed to call tool")
+
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Expected result field")
+		content, ok := resultData["content"].([]any)
+		require.True(t, ok, "Expected content array")
+		require.NotEmpty(t, content)
+		textContent, ok := content[0].(map[string]any)
+		require.True(t, ok, "Expected text content object")
+		assert.Contains(t, textContent["text"], "Echo: world")
+	})
+}
+
+func TestAggregatePartialFailure(t *testing.T) {
+	mcpServers := map[string]any{
+		"test-sse": map[string]any{
+			"transportType": "sse",
+			"url":           "http://localhost:3001/sse",
+		},
+		"bad-backend": map[string]any{
+			"transportType": "sse",
+			"url":           "http://localhost:9999/sse",
+		},
+		"mcp": map[string]any{
+			"type":          "aggregate",
+			"transportType": "sse",
+			"servers":       []string{"test-sse", "bad-backend"},
+			"discovery": map[string]any{
+				"timeout":  "3s",
+				"cacheTtl": "60s",
+			},
+		},
+	}
+	cfg := buildTestConfig("http://localhost:8080", "aggregate-partial-test", nil, mcpServers)
+	configPath := writeTestConfig(t, cfg)
+
+	startMCPFront(t, configPath)
+	waitForMCPFront(t)
+
+	client := NewMCPSSEClient("http://localhost:8080")
+	require.NotNil(t, client)
+	defer client.Close()
+
+	err := client.ConnectToServer("mcp")
+	require.NoError(t, err, "Failed to connect to aggregate endpoint")
+
+	result, err := client.SendMCPRequest("tools/list", map[string]any{})
+	require.NoError(t, err, "Failed to list tools")
+	require.NotContains(t, result, "error")
+
+	resultData, ok := result["result"].(map[string]any)
+	require.True(t, ok, "Expected result field")
+	tools, ok := resultData["tools"].([]any)
+	require.True(t, ok, "Expected tools array")
+
+	toolNames := make(map[string]bool)
+	for _, tool := range tools {
+		toolMap, ok := tool.(map[string]any)
+		if ok {
+			if name, ok := toolMap["name"].(string); ok {
+				toolNames[name] = true
+			}
+		}
+	}
+
+	assert.True(t, toolNames["test-sse.echo_text"], "Missing test-sse.echo_text")
+	assert.True(t, toolNames["test-sse.sample_stream"], "Missing test-sse.sample_stream")
+
+	for name := range toolNames {
+		assert.NotContains(t, name, "bad-backend", "Should not have tools from unreachable backend")
+	}
+}
+
+func TestAggregateToolFilter(t *testing.T) {
+	mcpServers := map[string]any{
+		"test-sse": map[string]any{
+			"transportType": "sse",
+			"url":           "http://localhost:3001/sse",
+			"options": map[string]any{
+				"toolFilter": map[string]any{
+					"mode": "block",
+					"list": []string{"sample_stream"},
+				},
+			},
+		},
+		"test-streamable": map[string]any{
+			"transportType": "streamable-http",
+			"url":           "http://localhost:3002",
+		},
+		"mcp": map[string]any{
+			"type":          "aggregate",
+			"transportType": "sse",
+			"discovery": map[string]any{
+				"timeout":  "10s",
+				"cacheTtl": "60s",
+			},
+		},
+	}
+	cfg := buildTestConfig("http://localhost:8080", "aggregate-filter-test", nil, mcpServers)
+	configPath := writeTestConfig(t, cfg)
+
+	startMCPFront(t, configPath)
+	waitForMCPFront(t)
+
+	client := NewMCPSSEClient("http://localhost:8080")
+	require.NotNil(t, client)
+	defer client.Close()
+
+	err := client.ConnectToServer("mcp")
+	require.NoError(t, err, "Failed to connect to aggregate endpoint")
+
+	result, err := client.SendMCPRequest("tools/list", map[string]any{})
+	require.NoError(t, err, "Failed to list tools")
+	require.NotContains(t, result, "error")
+
+	resultData, ok := result["result"].(map[string]any)
+	require.True(t, ok, "Expected result field")
+	tools, ok := resultData["tools"].([]any)
+	require.True(t, ok, "Expected tools array")
+
+	toolNames := make(map[string]bool)
+	for _, tool := range tools {
+		toolMap, ok := tool.(map[string]any)
+		if ok {
+			if name, ok := toolMap["name"].(string); ok {
+				toolNames[name] = true
+			}
+		}
+	}
+
+	assert.True(t, toolNames["test-sse.echo_text"], "echo_text should be present")
+	assert.False(t, toolNames["test-sse.sample_stream"], "sample_stream should be blocked by filter")
+
+	assert.True(t, toolNames["test-streamable.get_time"], "get_time should be unaffected")
+	assert.True(t, toolNames["test-streamable.echo_streamable"], "echo_streamable should be unaffected")
+}

--- a/integration/fixtures/mock-sse-server.js
+++ b/integration/fixtures/mock-sse-server.js
@@ -1,36 +1,127 @@
 const http = require('http');
+const crypto = require('crypto');
 
 const PORT = process.env.PORT || 3001;
 
-// Simple mock SSE MCP server for testing
+// Map of sessionId -> SSE response writer
+const sessions = new Map();
+
+function handleRequest(request) {
+  if (request.method === 'initialize') {
+    return {
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        protocolVersion: '2025-06-18',
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: { name: 'mock-sse-server', version: '1.0.0' }
+      }
+    };
+  }
+
+  if (request.method === 'tools/list') {
+    return {
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        tools: [
+          {
+            name: 'echo_text',
+            description: 'Echo the provided text',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                text: { type: 'string' }
+              },
+              required: ['text']
+            }
+          },
+          {
+            name: 'sample_stream',
+            description: 'Sample streaming tool',
+            inputSchema: {
+              type: 'object',
+              properties: {}
+            }
+          }
+        ]
+      }
+    };
+  }
+
+  if (request.method === 'tools/call') {
+    if (request.params.name === 'echo_text') {
+      return {
+        jsonrpc: '2.0',
+        id: request.id,
+        result: {
+          content: [{ type: 'text', text: request.params.arguments.text }]
+        }
+      };
+    }
+    if (request.params.name === 'non_existent_tool_xyz') {
+      return {
+        jsonrpc: '2.0',
+        id: request.id,
+        error: {
+          code: -32601,
+          message: 'Tool not found: ' + request.params.name
+        }
+      };
+    }
+    return {
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        content: [{ type: 'text', text: 'Tool executed successfully' }]
+      }
+    };
+  }
+
+  return {
+    jsonrpc: '2.0',
+    id: request.id,
+    result: {}
+  };
+}
+
 const server = http.createServer((req, res) => {
   console.log(`${req.method} ${req.url}`);
-  
+
   if (req.url === '/' && req.method === 'GET') {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end('Mock SSE MCP Server');
-  } else if (req.url === '/sse' && req.method === 'GET') {
-    // SSE endpoint
+    return;
+  }
+
+  if (req.url === '/sse' && req.method === 'GET') {
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
       'Connection': 'keep-alive',
       'Access-Control-Allow-Origin': '*'
     });
-    
-    // Send initial endpoint message
-    res.write('data: {"jsonrpc":"2.0","method":"endpoint","params":{"type":"endpoint","url":"/message"}}\n\n');
-    
-    // Keep connection alive
+
+    const sessionId = crypto.randomUUID();
+    sessions.set(sessionId, res);
+
+    res.write(`event: endpoint\ndata: /message?sessionId=${sessionId}\r\n\r\n`);
+
     const keepAlive = setInterval(() => {
       res.write(':keepalive\n\n');
     }, 30000);
-    
+
     req.on('close', () => {
       clearInterval(keepAlive);
+      sessions.delete(sessionId);
     });
-  } else if (req.url === '/message' && req.method === 'POST') {
-    // Message endpoint
+    return;
+  }
+
+  if (req.url.startsWith('/message') && req.method === 'POST') {
+    const urlObj = new URL(req.url, `http://localhost:${PORT}`);
+    const sessionId = urlObj.searchParams.get('sessionId');
+
     let body = '';
     req.on('data', chunk => {
       body += chunk.toString();
@@ -39,71 +130,24 @@ const server = http.createServer((req, res) => {
       try {
         const request = JSON.parse(body);
         console.log('Received request:', request);
-        
-        let response;
-        if (request.method === 'tools/list') {
-          response = {
-            jsonrpc: '2.0',
-            id: request.id,
-            result: {
-              tools: [
-                {
-                  name: 'echo_text',
-                  description: 'Echo the provided text',
-                  inputSchema: {
-                    type: 'object',
-                    properties: {
-                      text: { type: 'string' }
-                    },
-                    required: ['text']
-                  }
-                },
-                {
-                  name: 'sample_stream',
-                  description: 'Sample streaming tool',
-                  inputSchema: {
-                    type: 'object',
-                    properties: {}
-                  }
-                }
-              ]
-            }
-          };
-        } else if (request.method === 'tools/call') {
-          if (request.params.name === 'echo_text') {
-            response = {
-              jsonrpc: '2.0',
-              id: request.id,
-              result: {
-                toolResult: request.params.arguments.text
-              }
-            };
-          } else if (request.params.name === 'non_existent_tool_xyz') {
-            response = {
-              jsonrpc: '2.0',
-              id: request.id,
-              error: {
-                code: -32601,
-                message: 'Tool not found: ' + request.params.name
-              }
-            };
-          } else {
-            response = {
-              jsonrpc: '2.0',
-              id: request.id,
-              result: {
-                toolResult: 'Tool executed successfully'
-              }
-            };
-          }
-        } else {
-          response = {
-            jsonrpc: '2.0',
-            id: request.id,
-            result: {}
-          };
+
+        // Notifications have no id - just acknowledge
+        if (!request.id) {
+          res.writeHead(202);
+          res.end();
+          return;
         }
-        
+
+        const response = handleRequest(request);
+        const sseRes = sessionId ? sessions.get(sessionId) : null;
+
+        if (sseRes) {
+          // Deliver via SSE stream (mcp-go SSE clients read responses from the stream)
+          const data = JSON.stringify(response);
+          sseRes.write(`event: message\ndata: ${data}\r\n\r\n`);
+        }
+
+        // Return response in POST body (direct proxy clients read from the body)
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(response));
       } catch (e) {
@@ -119,10 +163,11 @@ const server = http.createServer((req, res) => {
         }));
       }
     });
-  } else {
-    res.writeHead(404, { 'Content-Type': 'text/plain' });
-    res.end('Not found');
+    return;
   }
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not found');
 });
 
 server.listen(PORT, () => {

--- a/integration/fixtures/mock-streamable-server.js
+++ b/integration/fixtures/mock-streamable-server.js
@@ -2,41 +2,33 @@ const http = require('http');
 
 const PORT = process.env.PORT || 3002;
 
-// Mock HTTP-Streamable MCP server for testing
 const server = http.createServer((req, res) => {
   console.log(`${req.method} ${req.url}`);
-  
+
   if (req.method === 'GET' && req.headers.accept?.includes('text/event-stream')) {
-    // Handle GET requests for SSE streaming
-    // Return SSE stream
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
       'Connection': 'keep-alive'
     });
-    
-    // Send initial endpoint message (expected by test client)
+
     res.write('data: {"jsonrpc":"2.0","method":"endpoint","params":{"type":"endpoint","url":"/message"}}\n\n');
-    
-    // Keep connection alive with periodic messages
+
     const keepAlive = setInterval(() => {
       res.write(':keepalive\n\n');
     }, 30000);
-    
-    // Send some server-initiated messages
+
     setTimeout(() => {
       res.write('data: {"jsonrpc":"2.0","method":"notification","params":{"type":"server_info","version":"1.0"}}\n\n');
     }, 1000);
-    
+
     req.on('close', () => {
       clearInterval(keepAlive);
     });
   } else if (req.url === '/' && req.method === 'GET') {
-    // Health check endpoint
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end('Mock Streamable MCP Server');
   } else if (req.method === 'POST') {
-    // Handle POST requests (single endpoint for streamable)
     let body = '';
     req.on('data', chunk => {
       body += chunk.toString();
@@ -45,12 +37,29 @@ const server = http.createServer((req, res) => {
       try {
         const request = JSON.parse(body);
         console.log('Received request:', request);
-        
-        // Check Accept header to decide response type
+
+        if (!request.id) {
+          res.writeHead(200);
+          res.end();
+          return;
+        }
+
         const acceptHeader = req.headers.accept || '';
         const wantsSSE = acceptHeader.includes('text/event-stream');
-        
-        if (request.method === 'tools/list') {
+
+        if (request.method === 'initialize') {
+          const response = {
+            jsonrpc: '2.0',
+            id: request.id,
+            result: {
+              protocolVersion: '2025-06-18',
+              capabilities: { tools: { listChanged: false } },
+              serverInfo: { name: 'mock-streamable-server', version: '1.0.0' }
+            }
+          };
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(response));
+        } else if (request.method === 'tools/list') {
           const response = {
             jsonrpc: '2.0',
             id: request.id,
@@ -78,7 +87,7 @@ const server = http.createServer((req, res) => {
               ]
             }
           };
-          
+
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify(response));
         } else if (request.method === 'tools/call') {
@@ -87,42 +96,39 @@ const server = http.createServer((req, res) => {
               jsonrpc: '2.0',
               id: request.id,
               result: {
-                toolResult: new Date().toISOString()
+                content: [{ type: 'text', text: new Date().toISOString() }]
               }
             };
             res.writeHead(200, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify(response));
           } else if (request.params.name === 'echo_streamable') {
             if (wantsSSE) {
-              // Return SSE stream for this tool
               res.writeHead(200, {
                 'Content-Type': 'text/event-stream',
                 'Cache-Control': 'no-cache',
                 'Connection': 'keep-alive'
               });
-              
-              // Send multiple responses in SSE format
+
               const messages = [
-                { jsonrpc: '2.0', id: request.id, result: { toolResult: `Echo: ${request.params.arguments.text}` } },
+                { jsonrpc: '2.0', id: request.id, result: { content: [{ type: 'text', text: `Echo: ${request.params.arguments.text}` }] } },
                 { jsonrpc: '2.0', method: 'notification', params: { message: 'Processing complete' } }
               ];
-              
+
               messages.forEach((msg, index) => {
                 setTimeout(() => {
                   res.write(`data: ${JSON.stringify(msg)}\n\n`);
                 }, index * 100);
               });
-              
+
               setTimeout(() => {
                 res.end();
               }, 300);
             } else {
-              // Regular JSON response
               const response = {
                 jsonrpc: '2.0',
                 id: request.id,
                 result: {
-                  toolResult: `Echo: ${request.params.arguments.text}`
+                  content: [{ type: 'text', text: `Echo: ${request.params.arguments.text}` }]
                 }
               };
               res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -141,7 +147,6 @@ const server = http.createServer((req, res) => {
             res.end(JSON.stringify(response));
           }
         } else {
-          // Default response for other methods
           const response = {
             jsonrpc: '2.0',
             id: request.id,

--- a/integration/sse_test.go
+++ b/integration/sse_test.go
@@ -64,15 +64,15 @@ func TestSSEServerIntegration(t *testing.T) {
 			t.Fatalf("Got error response: %v", errorMap)
 		}
 
-		// Verify we got a result
-		assert.NotNil(t, result["result"])
-
-		// Verify the echo result contains our text
-		if resultData, ok := result["result"].(map[string]any); ok {
-			if toolResult, ok := resultData["toolResult"].(string); ok {
-				assert.Equal(t, "Hello from SSE test!", toolResult)
-			}
-		}
+		// Verify we got a result with MCP content format
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Expected result field")
+		content, ok := resultData["content"].([]any)
+		require.True(t, ok, "Expected content array")
+		require.NotEmpty(t, content)
+		textContent, ok := content[0].(map[string]any)
+		require.True(t, ok, "Expected text content object")
+		assert.Equal(t, "Hello from SSE test!", textContent["text"])
 	})
 
 	t.Run("SSE server disconnection handling", func(t *testing.T) {
@@ -107,11 +107,16 @@ func TestSSEServerIntegration(t *testing.T) {
 		require.NoError(t, err, "Connection error during streaming test")
 		assert.NotNil(t, result)
 
-		// Verify we got a successful result
+		// Verify we got a successful result with MCP content format
 		assert.NotContains(t, result, "error", "Should not have error for sample_stream")
-		if resultData, ok := result["result"].(map[string]any); ok {
-			assert.Equal(t, "Tool executed successfully", resultData["toolResult"])
-		}
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Expected result field")
+		content, ok := resultData["content"].([]any)
+		require.True(t, ok, "Expected content array")
+		require.NotEmpty(t, content)
+		textContent, ok := content[0].(map[string]any)
+		require.True(t, ok, "Expected text content object")
+		assert.Equal(t, "Tool executed successfully", textContent["text"])
 	})
 
 	t.Run("SSE error handling", func(t *testing.T) {

--- a/integration/streamable_test.go
+++ b/integration/streamable_test.go
@@ -73,16 +73,16 @@ func TestStreamableServerIntegration(t *testing.T) {
 			t.Fatalf("Got error response: %v", errorMap)
 		}
 
-		// Verify we got a result
-		assert.NotNil(t, result["result"])
-
-		// Verify the time result
-		if resultData, ok := result["result"].(map[string]any); ok {
-			if toolResult, ok := resultData["toolResult"].(string); ok {
-				assert.NotEmpty(t, toolResult, "Should have gotten a timestamp")
-				t.Logf("Got time: %s", toolResult)
-			}
-		}
+		// Verify we got a result with MCP content format
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Expected result field")
+		content, ok := resultData["content"].([]any)
+		require.True(t, ok, "Expected content array")
+		require.NotEmpty(t, content)
+		textContent, ok := content[0].(map[string]any)
+		require.True(t, ok, "Expected text content object")
+		assert.NotEmpty(t, textContent["text"], "Should have gotten a timestamp")
+		t.Logf("Got time: %s", textContent["text"])
 	})
 
 	t.Run("Streamable POST with actual SSE response", func(t *testing.T) {
@@ -139,10 +139,12 @@ func TestStreamableServerIntegration(t *testing.T) {
 		for _, response := range responses {
 			if id, ok := response["id"]; ok && id == float64(1) {
 				if result, ok := response["result"].(map[string]any); ok {
-					if toolResult, ok := result["toolResult"].(string); ok {
-						assert.Equal(t, "Echo: Hello SSE!", toolResult)
-						found = true
-						break
+					if content, ok := result["content"].([]any); ok && len(content) > 0 {
+						if textContent, ok := content[0].(map[string]any); ok {
+							assert.Equal(t, "Echo: Hello SSE!", textContent["text"])
+							found = true
+							break
+						}
 					}
 				}
 			}

--- a/integration/test_clients.go
+++ b/integration/test_clients.go
@@ -87,20 +87,42 @@ func (c *MCPSSEClient) ConnectToServer(serverName string) error {
 	c.sseScanner = bufio.NewScanner(resp.Body)
 
 	// Read initial SSE messages to get the endpoint
-	// For inline servers, we don't get a message endpoint - we use the server path directly
-	gotEndpointMessage := false
+	// Handles three formats:
+	// 1. event: endpoint + data: <relative-url> (proper MCP SSE protocol)
+	// 2. data: {"...":"endpoint"...} (inline server JSON blob)
+	// 3. data: http://... (full URL for stdio servers)
+	var currentEvent string
 	for c.sseScanner.Scan() {
 		line := c.sseScanner.Text()
 		tracef("ConnectToServer: SSE line: %s", line)
+
+		// Track SSE event type
+		if after, ok := strings.CutPrefix(line, "event: "); ok {
+			currentEvent = after
+			continue
+		}
 
 		// Look for data lines
 		if after, ok := strings.CutPrefix(line, "data: "); ok {
 			data := after
 
+			// Handle proper MCP SSE endpoint event
+			if currentEvent == "endpoint" {
+				if strings.HasPrefix(data, "/") {
+					// Relative URL - resolve against mcp-front base with server name prefix
+					c.messageEndpoint = c.baseURL + "/" + serverName + data
+				} else if strings.HasPrefix(data, "http") {
+					c.messageEndpoint = data
+				}
+				if u, err := url.Parse(c.messageEndpoint); err == nil {
+					c.sessionID = u.Query().Get("sessionId")
+				}
+				tracef("ConnectToServer: endpoint event, using: %s", c.messageEndpoint)
+				break
+			}
+
 			// Check if it's an endpoint message (for inline servers)
 			if strings.Contains(data, `"type":"endpoint"`) {
-				gotEndpointMessage = true
-				// For inline servers, construct the message endpoint
 				c.messageEndpoint = c.baseURL + "/" + serverName + "/message"
 				tracef("ConnectToServer: inline server detected, using endpoint: %s", c.messageEndpoint)
 				break
@@ -109,19 +131,18 @@ func (c *MCPSSEClient) ConnectToServer(serverName string) error {
 			// Check if it's a message endpoint URL (for stdio servers)
 			if strings.Contains(data, "http://") || strings.Contains(data, "https://") {
 				c.messageEndpoint = data
-
-				// Extract session ID from endpoint URL
 				if u, err := url.Parse(data); err == nil {
 					c.sessionID = u.Query().Get("sessionId")
 				}
-
 				tracef("ConnectToServer: found endpoint: %s", c.messageEndpoint)
 				break
 			}
+
+			currentEvent = ""
 		}
 	}
 
-	if c.messageEndpoint == "" && !gotEndpointMessage {
+	if c.messageEndpoint == "" {
 		c.sseConn.Close()
 		c.sseConn = nil
 		return fmt.Errorf("no message endpoint received")

--- a/internal/aggregate/namespace.go
+++ b/internal/aggregate/namespace.go
@@ -1,0 +1,15 @@
+package aggregate
+
+import "strings"
+
+func PrefixToolName(serverName, toolName string) string {
+	return serverName + "." + toolName
+}
+
+func ParseToolName(namespacedName string) (serverName, toolName string, ok bool) {
+	idx := strings.IndexByte(namespacedName, '.')
+	if idx < 0 {
+		return "", "", false
+	}
+	return namespacedName[:idx], namespacedName[idx+1:], true
+}

--- a/internal/aggregate/namespace_test.go
+++ b/internal/aggregate/namespace_test.go
@@ -1,0 +1,44 @@
+package aggregate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrefixToolName(t *testing.T) {
+	assert.Equal(t, "postgres.query", PrefixToolName("postgres", "query"))
+	assert.Equal(t, "linear.create_issue", PrefixToolName("linear", "create_issue"))
+}
+
+func TestParseToolName(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantServer string
+		wantTool   string
+		wantOK     bool
+	}{
+		{"basic", "postgres.query", "postgres", "query", true},
+		{"dotted_tool", "postgres.schema.list", "postgres", "schema.list", true},
+		{"no_dot", "query", "", "", false},
+		{"empty", "", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, tool, ok := ParseToolName(tt.input)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantServer, server)
+			assert.Equal(t, tt.wantTool, tool)
+		})
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	prefixed := PrefixToolName("linear", "create_issue")
+	server, tool, ok := ParseToolName(prefixed)
+	assert.True(t, ok)
+	assert.Equal(t, "linear", server)
+	assert.Equal(t, "create_issue", tool)
+}

--- a/internal/aggregate/server.go
+++ b/internal/aggregate/server.go
@@ -1,0 +1,613 @@
+package aggregate
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/dgellow/mcp-front/internal/client"
+	"github.com/dgellow/mcp-front/internal/config"
+	"github.com/dgellow/mcp-front/internal/log"
+	"github.com/dgellow/mcp-front/internal/oauth"
+	"github.com/dgellow/mcp-front/internal/servicecontext"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	connIdleTimeout     = 5 * time.Minute
+	connCleanupInterval = 1 * time.Minute
+)
+
+var ErrUserConnLimitExceeded = fmt.Errorf("user connection limit exceeded")
+
+// UserTokenFunc retrieves a user's token for a specific backend service.
+type UserTokenFunc func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error)
+
+// connKey identifies a per-user, per-backend connection.
+type connKey struct {
+	userEmail   string
+	backendName string
+}
+
+func (k connKey) String() string { return k.userEmail + "\x00" + k.backendName }
+
+// conn is a long-lived connection to one backend for one user.
+type conn struct {
+	client       client.MCPClientInterface
+	cancel       context.CancelFunc
+	lastAccessed atomic.Pointer[time.Time]
+}
+
+// cachedTools holds discovered tool schemas. Global, not per-user.
+type cachedTools struct {
+	tools   map[string][]mcp.Tool // backendName -> filtered tools
+	expires time.Time
+}
+
+// mcpTransport is satisfied by both mcpserver.SSEServer and mcpserver.StreamableHTTPServer.
+type mcpTransport interface {
+	http.Handler
+	Shutdown(context.Context) error
+}
+
+// Server aggregates multiple MCP backends into a single endpoint.
+// Tools from backends are namespaced as "backend.toolName".
+type Server struct {
+	name            string
+	backends        map[string]*config.MCPClientConfig
+	discovery       *config.DiscoveryConfig
+	getUserToken    UserTokenFunc
+	createTransport client.TransportCreator
+	baseURL         string
+
+	cacheMu        sync.RWMutex
+	cache          *cachedTools
+	discoveryGroup singleflight.Group
+
+	connMu    sync.RWMutex
+	conns     map[connKey]*conn
+	closed    bool
+	connGroup singleflight.Group
+
+	mcpServer *mcpserver.MCPServer
+	transport mcpTransport
+
+	stopCleanup  chan struct{}
+	shutdownOnce sync.Once
+	wg           sync.WaitGroup
+}
+
+type ServerConfig struct {
+	Name            string
+	TransportType   config.MCPClientType
+	Backends        map[string]*config.MCPClientConfig
+	Discovery       *config.DiscoveryConfig
+	GetUserToken    UserTokenFunc
+	CreateTransport client.TransportCreator
+	BaseURL         string
+}
+
+func NewServer(cfg ServerConfig) *Server {
+	s := &Server{
+		name:            cfg.Name,
+		backends:        cfg.Backends,
+		discovery:       cfg.Discovery,
+		getUserToken:    cfg.GetUserToken,
+		createTransport: cfg.CreateTransport,
+		baseURL:         cfg.BaseURL,
+		conns:           make(map[connKey]*conn),
+		stopCleanup:     make(chan struct{}),
+	}
+
+	hooks := &mcpserver.Hooks{}
+	hooks.AddOnRegisterSession(s.onRegisterSession)
+
+	s.mcpServer = mcpserver.NewMCPServer(cfg.Name, "1.0.0",
+		mcpserver.WithHooks(hooks),
+		mcpserver.WithToolCapabilities(true),
+	)
+
+	switch cfg.TransportType {
+	case config.MCPClientTypeStreamable:
+		streamable := mcpserver.NewStreamableHTTPServer(s.mcpServer,
+			mcpserver.WithEndpointPath("/"+cfg.Name+"/"),
+			mcpserver.WithHTTPContextFunc(func(ctx context.Context, r *http.Request) context.Context {
+				return r.Context()
+			}),
+		)
+		s.transport = streamable
+	default:
+		sse := mcpserver.NewSSEServer(s.mcpServer,
+			mcpserver.WithStaticBasePath(cfg.Name),
+			mcpserver.WithBaseURL(cfg.BaseURL),
+		)
+		s.transport = sse
+	}
+
+	return s
+}
+
+func (s *Server) Start() {
+	s.wg.Add(1)
+	go s.cleanupLoop()
+}
+
+func (s *Server) Handler() http.Handler {
+	return s.transport
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	var err error
+	s.shutdownOnce.Do(func() {
+		close(s.stopCleanup)
+		s.wg.Wait()
+
+		err = s.transport.Shutdown(ctx)
+
+		s.connMu.Lock()
+		s.closed = true
+		snapshot := make(map[connKey]*conn, len(s.conns))
+		maps.Copy(snapshot, s.conns)
+		clear(s.conns)
+		s.connMu.Unlock()
+
+		for key, c := range snapshot {
+			c.cancel()
+			if closeErr := c.client.Close(); closeErr != nil {
+				log.LogWarnWithFields("aggregate", "Error closing backend connection", map[string]any{
+					"server":  s.name,
+					"backend": key.backendName,
+					"user":    key.userEmail,
+					"error":   closeErr.Error(),
+				})
+			}
+		}
+	})
+	return err
+}
+
+func (s *Server) onRegisterSession(ctx context.Context, session mcpserver.ClientSession) {
+	userEmail, _ := oauth.GetUserFromContext(ctx)
+	if userEmail == "" {
+		userEmail, _ = servicecontext.GetUser(ctx)
+	}
+	if userEmail == "" {
+		userEmail = "anonymous"
+		log.LogInfoWithFields("aggregate", "No user identity in session context, using anonymous", map[string]any{
+			"server":    s.name,
+			"sessionID": session.SessionID(),
+		})
+	}
+
+	tools, err := s.getTools(ctx, userEmail)
+	if err != nil {
+		log.LogErrorWithFields("aggregate", "Tool discovery failed", map[string]any{
+			"server": s.name,
+			"user":   userEmail,
+			"error":  err.Error(),
+		})
+		return
+	}
+
+	sessionWithTools, ok := session.(mcpserver.SessionWithTools)
+	if !ok {
+		log.LogErrorWithFields("aggregate", "Session does not support per-session tools", map[string]any{
+			"server":    s.name,
+			"sessionID": session.SessionID(),
+		})
+		return
+	}
+
+	sessionTools := make(map[string]mcpserver.ServerTool)
+	for backendName, backendTools := range tools {
+		for _, tool := range backendTools {
+			namespacedName := PrefixToolName(backendName, tool.Name)
+			tool.Name = namespacedName
+			sessionTools[namespacedName] = mcpserver.ServerTool{
+				Tool:    tool,
+				Handler: s.makeToolHandler(userEmail, backendName),
+			}
+		}
+	}
+	sessionWithTools.SetSessionTools(sessionTools)
+
+	log.LogInfoWithFields("aggregate", "Session registered", map[string]any{
+		"server":    s.name,
+		"sessionID": session.SessionID(),
+		"user":      userEmail,
+		"toolCount": len(sessionTools),
+	})
+}
+
+// getTools returns cached tool schemas or triggers fresh discovery.
+// Uses singleflight to prevent concurrent discoveries (cache stampede).
+//
+// The singleflight key is global ("discover"), not per-user: tool schemas are
+// the same for all users of a given backend, so the cache is intentionally shared.
+// The first caller to trigger discovery authenticates backend connections with their
+// credentials. Actual tool calls use per-user connections via getOrCreateConn.
+func (s *Server) getTools(ctx context.Context, userEmail string) (map[string][]mcp.Tool, error) {
+	s.cacheMu.RLock()
+	if s.cache != nil && time.Now().Before(s.cache.expires) {
+		tools := s.cache.tools
+		s.cacheMu.RUnlock()
+		return tools, nil
+	}
+	s.cacheMu.RUnlock()
+
+	v, err, _ := s.discoveryGroup.Do("discover", func() (any, error) {
+		// Double-check inside singleflight
+		s.cacheMu.RLock()
+		if s.cache != nil && time.Now().Before(s.cache.expires) {
+			tools := s.cache.tools
+			s.cacheMu.RUnlock()
+			return tools, nil
+		}
+		s.cacheMu.RUnlock()
+
+		// Detach from the caller's context: singleflight shares this result
+		// with all concurrent callers. If the first caller's context is
+		// cancelled (e.g., SSE disconnect), discovery would fail for everyone.
+		// discoverAllTools applies its own timeout from DiscoveryConfig.
+		discoveryCtx := context.WithoutCancel(ctx)
+		return s.discoverAllTools(discoveryCtx, userEmail)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return v.(map[string][]mcp.Tool), nil
+}
+
+// discoverAllTools fans out to all backends in parallel.
+func (s *Server) discoverAllTools(ctx context.Context, userEmail string) (map[string][]mcp.Tool, error) {
+	discoveryCtx, cancel := context.WithTimeout(ctx, s.discovery.Timeout)
+	defer cancel()
+
+	type result struct {
+		backendName string
+		tools       []mcp.Tool
+		err         error
+	}
+
+	ch := make(chan result, len(s.backends))
+
+	for name, conf := range s.backends {
+		go func(name string, conf *config.MCPClientConfig) {
+			tools, err := s.discoverBackendTools(discoveryCtx, userEmail, name, conf)
+			ch <- result{backendName: name, tools: tools, err: err}
+		}(name, conf)
+	}
+
+	allTools := make(map[string][]mcp.Tool)
+	var errors []string
+
+	for range s.backends {
+		r := <-ch
+		if r.err != nil {
+			log.LogWarnWithFields("aggregate", "Backend discovery failed", map[string]any{
+				"server":  s.name,
+				"backend": r.backendName,
+				"error":   r.err.Error(),
+			})
+			errors = append(errors, fmt.Sprintf("%s: %v", r.backendName, r.err))
+			continue
+		}
+		allTools[r.backendName] = r.tools
+	}
+
+	totalTools := 0
+	for _, tools := range allTools {
+		totalTools += len(tools)
+	}
+
+	if totalTools == 0 && len(errors) > 0 {
+		return nil, fmt.Errorf("all backends failed discovery: %s", strings.Join(errors, "; "))
+	}
+
+	s.cacheMu.Lock()
+	s.cache = &cachedTools{
+		tools:   allTools,
+		expires: time.Now().Add(s.discovery.CacheTTL),
+	}
+	s.cacheMu.Unlock()
+
+	log.LogInfoWithFields("aggregate", "Tool discovery completed", map[string]any{
+		"server":    s.name,
+		"toolCount": totalTools,
+		"errors":    len(errors),
+	})
+
+	return allTools, nil
+}
+
+// discoverBackendTools connects to a backend, lists its tools, and applies filtering.
+func (s *Server) discoverBackendTools(ctx context.Context, userEmail, backendName string, conf *config.MCPClientConfig) ([]mcp.Tool, error) {
+	c, err := s.getOrCreateConn(ctx, userEmail, backendName)
+	if err != nil {
+		return nil, err
+	}
+
+	var tools []mcp.Tool
+	req := mcp.ListToolsRequest{}
+	for {
+		resp, err := c.client.ListTools(ctx, req)
+		if err != nil {
+			s.evictConn(connKey{userEmail: userEmail, backendName: backendName}, c)
+			return nil, fmt.Errorf("listing tools: %w", err)
+		}
+		tools = append(tools, resp.Tools...)
+		if resp.NextCursor == "" {
+			break
+		}
+		req.Params.Cursor = resp.NextCursor
+	}
+
+	filter := toolFilterFunc(conf)
+	filtered := make([]mcp.Tool, 0, len(tools))
+	for _, tool := range tools {
+		if filter(tool.Name) {
+			filtered = append(filtered, tool)
+		}
+	}
+
+	return filtered, nil
+}
+
+func (s *Server) makeToolHandler(userEmail, backendName string) mcpserver.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		_, originalName, ok := ParseToolName(request.Params.Name)
+		if !ok {
+			return nil, fmt.Errorf("invalid namespaced tool name: %s", request.Params.Name)
+		}
+
+		c, err := s.getOrCreateConn(ctx, userEmail, backendName)
+		if err != nil {
+			return nil, fmt.Errorf("backend %s: %w", backendName, err)
+		}
+
+		now := time.Now()
+		c.lastAccessed.Store(&now)
+
+		request.Params.Name = originalName
+		result, err := c.client.CallTool(ctx, request)
+		if err != nil {
+			// An error return means transport failure (broken pipe, connection
+			// reset, etc). MCP-level tool errors are returned in the result
+			// with IsError set, not via the error return. Evict the broken
+			// connection so the next call creates a fresh one.
+			s.evictConn(connKey{userEmail: userEmail, backendName: backendName}, c)
+		}
+		return result, err
+	}
+}
+
+func (s *Server) getOrCreateConn(ctx context.Context, userEmail, backendName string) (*conn, error) {
+	key := connKey{userEmail: userEmail, backendName: backendName}
+
+	v, err, _ := s.connGroup.Do(key.String(), func() (any, error) {
+		s.connMu.RLock()
+		existing, ok := s.conns[key]
+		s.connMu.RUnlock()
+
+		if ok {
+			now := time.Now()
+			existing.lastAccessed.Store(&now)
+			return existing, nil
+		}
+
+		// Detach from the caller's context: singleflight shares this result
+		// with concurrent callers for the same user+backend. createConn
+		// applies its own timeout for the Initialize exchange.
+		connCtx := context.WithoutCancel(ctx)
+		return s.createConn(connCtx, userEmail, backendName)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return v.(*conn), nil
+}
+
+// evictConn removes a broken connection from the pool if it's still the current
+// one for that key. The identity check (current == broken) prevents evicting a
+// replacement that was created after the error occurred. Concurrent callers
+// using the same broken connection will get transport errors and retry, which
+// is correct since the connection is already broken.
+func (s *Server) evictConn(key connKey, broken *conn) {
+	s.connMu.Lock()
+	current, ok := s.conns[key]
+	if ok && current == broken {
+		delete(s.conns, key)
+	} else {
+		ok = false
+	}
+	s.connMu.Unlock()
+
+	if ok {
+		broken.cancel()
+		broken.client.Close()
+		log.LogInfoWithFields("aggregate", "Evicted broken backend connection", map[string]any{
+			"server":  s.name,
+			"backend": key.backendName,
+			"user":    key.userEmail,
+		})
+	}
+}
+
+func (s *Server) checkUserConnLimit(userEmail string) error {
+	limit := s.discovery.MaxConnsPerUser
+	if limit == 0 || userEmail == "anonymous" {
+		return nil
+	}
+
+	s.connMu.RLock()
+	count := 0
+	for key := range s.conns {
+		if key.userEmail == userEmail {
+			count++
+		}
+	}
+	s.connMu.RUnlock()
+
+	if count >= limit {
+		return fmt.Errorf("%w: user %s has %d connections (limit: %d)",
+			ErrUserConnLimitExceeded, userEmail, count, limit)
+	}
+	return nil
+}
+
+func (s *Server) createConn(ctx context.Context, userEmail, backendName string) (*conn, error) {
+	if err := s.checkUserConnLimit(userEmail); err != nil {
+		return nil, err
+	}
+
+	backendConfig := s.backends[backendName]
+
+	effectiveConfig := backendConfig
+	if backendConfig.RequiresUserToken && userEmail != "" && s.getUserToken != nil {
+		token, err := s.getUserToken(ctx, userEmail, backendName, backendConfig)
+		if err != nil {
+			log.LogWarnWithFields("aggregate", "Failed to get user token", map[string]any{
+				"server":  s.name,
+				"backend": backendName,
+				"user":    userEmail,
+				"error":   err.Error(),
+			})
+		} else if token != "" {
+			effectiveConfig = backendConfig.ApplyUserToken(token)
+		}
+	}
+
+	transport, err := s.createTransport(effectiveConfig)
+	if err != nil {
+		return nil, fmt.Errorf("creating transport: %w", err)
+	}
+
+	connCtx, cancel := context.WithCancel(context.Background())
+
+	if err := transport.Start(connCtx); err != nil {
+		cancel()
+		transport.Close()
+		return nil, fmt.Errorf("starting: %w", err)
+	}
+
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{Name: s.name, Version: "1.0.0"}
+	// Initialize is a request-response exchange with its own timeout.
+	// The caller's context is detached (via WithoutCancel in singleflight)
+	// so we apply the discovery timeout as an upper bound.
+	// Start uses connCtx (background) because for SSE it controls the
+	// persistent stream lifetime.
+	initCtx, initCancel := context.WithTimeout(ctx, s.discovery.Timeout)
+	defer initCancel()
+	if _, err := transport.Initialize(initCtx, initReq); err != nil {
+		cancel()
+		transport.Close()
+		return nil, fmt.Errorf("initializing: %w", err)
+	}
+
+	now := time.Now()
+	c := &conn{
+		client: transport,
+		cancel: cancel,
+	}
+	c.lastAccessed.Store(&now)
+
+	key := connKey{userEmail: userEmail, backendName: backendName}
+	s.connMu.Lock()
+	if s.closed {
+		s.connMu.Unlock()
+		cancel()
+		transport.Close()
+		return nil, fmt.Errorf("server is shut down")
+	}
+	s.conns[key] = c
+	s.connMu.Unlock()
+
+	log.LogInfoWithFields("aggregate", "Backend connection established", map[string]any{
+		"server":  s.name,
+		"backend": backendName,
+		"user":    userEmail,
+	})
+
+	return c, nil
+}
+
+func (s *Server) cleanupLoop() {
+	defer s.wg.Done()
+	ticker := time.NewTicker(connCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.stopCleanup:
+			return
+		case <-ticker.C:
+			s.cleanupIdleConns()
+		}
+	}
+}
+
+func (s *Server) cleanupIdleConns() {
+	now := time.Now()
+
+	s.connMu.Lock()
+	var toClose []*conn
+	var toLog []connKey
+	for key, c := range s.conns {
+		last := c.lastAccessed.Load()
+		if last != nil && now.Sub(*last) > connIdleTimeout {
+			toClose = append(toClose, c)
+			toLog = append(toLog, key)
+			delete(s.conns, key)
+		}
+	}
+	s.connMu.Unlock()
+
+	for i, c := range toClose {
+		log.LogInfoWithFields("aggregate", "Closing idle connection", map[string]any{
+			"server":  s.name,
+			"backend": toLog[i].backendName,
+			"user":    toLog[i].userEmail,
+		})
+		c.cancel()
+		c.client.Close()
+	}
+}
+
+// toolFilterFunc builds a filter predicate from a backend's config.
+func toolFilterFunc(conf *config.MCPClientConfig) func(string) bool {
+	if conf.Options == nil || conf.Options.ToolFilter == nil || len(conf.Options.ToolFilter.List) == 0 {
+		return func(string) bool { return true }
+	}
+
+	filter := conf.Options.ToolFilter
+	set := make(map[string]struct{}, len(filter.List))
+	for _, name := range filter.List {
+		set[name] = struct{}{}
+	}
+
+	switch config.ToolFilterMode(strings.ToLower(string(filter.Mode))) {
+	case config.ToolFilterModeAllow:
+		return func(name string) bool {
+			_, ok := set[name]
+			return ok
+		}
+	case config.ToolFilterModeBlock:
+		return func(name string) bool {
+			_, ok := set[name]
+			return !ok
+		}
+	default:
+		panic(fmt.Sprintf("aggregate: invalid tool filter mode %q (should have been caught by config validation)", filter.Mode))
+	}
+}

--- a/internal/aggregate/server_test.go
+++ b/internal/aggregate/server_test.go
@@ -1,0 +1,989 @@
+package aggregate
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dgellow/mcp-front/internal/client"
+	"github.com/dgellow/mcp-front/internal/config"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTransport implements client.MCPClientInterface for testing.
+// When Close() is called, all in-flight operations that select on closeCh
+// will fail — matching real transport behavior where closing the underlying
+// connection interrupts pending requests.
+type mockTransport struct {
+	mu            sync.Mutex
+	tools         []mcp.Tool
+	callToolFn    func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error)
+	initDelay     time.Duration
+	listDelay     time.Duration
+	started       bool
+	initialized   bool
+	closed        bool
+	closeCh       chan struct{}
+	startErr      error
+	initializeErr error
+	listToolsErr  error
+}
+
+func newMockTransport(tools []mcp.Tool) *mockTransport {
+	return &mockTransport{
+		tools:   tools,
+		closeCh: make(chan struct{}),
+	}
+}
+
+func (m *mockTransport) Start(ctx context.Context) error {
+	if m.startErr != nil {
+		return m.startErr
+	}
+	m.mu.Lock()
+	m.started = true
+	if m.closeCh == nil {
+		m.closeCh = make(chan struct{})
+	}
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *mockTransport) Initialize(ctx context.Context, req mcp.InitializeRequest) (*mcp.InitializeResult, error) {
+	if m.initDelay > 0 {
+		select {
+		case <-time.After(m.initDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if m.initializeErr != nil {
+		return nil, m.initializeErr
+	}
+	m.mu.Lock()
+	m.initialized = true
+	m.mu.Unlock()
+	return &mcp.InitializeResult{}, nil
+}
+
+func (m *mockTransport) ListTools(ctx context.Context, req mcp.ListToolsRequest) (*mcp.ListToolsResult, error) {
+	if m.listDelay > 0 {
+		select {
+		case <-time.After(m.listDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if m.listToolsErr != nil {
+		return nil, m.listToolsErr
+	}
+	m.mu.Lock()
+	tools := make([]mcp.Tool, len(m.tools))
+	copy(tools, m.tools)
+	m.mu.Unlock()
+	return &mcp.ListToolsResult{Tools: tools}, nil
+}
+
+func (m *mockTransport) CallTool(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if m.callToolFn != nil {
+		return m.callToolFn(ctx, req)
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{mcp.NewTextContent("ok")},
+	}, nil
+}
+
+func (m *mockTransport) ListPrompts(ctx context.Context, req mcp.ListPromptsRequest) (*mcp.ListPromptsResult, error) {
+	return &mcp.ListPromptsResult{}, nil
+}
+
+func (m *mockTransport) GetPrompt(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	return &mcp.GetPromptResult{}, nil
+}
+
+func (m *mockTransport) ListResources(ctx context.Context, req mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error) {
+	return &mcp.ListResourcesResult{}, nil
+}
+
+func (m *mockTransport) ReadResource(ctx context.Context, req mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	return &mcp.ReadResourceResult{}, nil
+}
+
+func (m *mockTransport) ListResourceTemplates(ctx context.Context, req mcp.ListResourceTemplatesRequest) (*mcp.ListResourceTemplatesResult, error) {
+	return &mcp.ListResourceTemplatesResult{}, nil
+}
+
+func (m *mockTransport) Ping(ctx context.Context) error { return nil }
+
+// slowInitTransport wraps mockTransport with a controllable Initialize delay
+// for testing singleflight context propagation.
+type slowInitTransport struct {
+	*mockTransport
+	initStarted chan struct{}
+	initProceed chan struct{}
+}
+
+func (s *slowInitTransport) Initialize(ctx context.Context, req mcp.InitializeRequest) (*mcp.InitializeResult, error) {
+	select {
+	case s.initStarted <- struct{}{}:
+	default:
+	}
+	select {
+	case <-s.initProceed:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return s.mockTransport.Initialize(ctx, req)
+}
+
+func (m *mockTransport) Close() error {
+	m.mu.Lock()
+	alreadyClosed := m.closed
+	m.closed = true
+	m.mu.Unlock()
+	if !alreadyClosed && m.closeCh != nil {
+		close(m.closeCh)
+	}
+	return nil
+}
+
+func (m *mockTransport) isClosed() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closed
+}
+
+// newTestServer creates a Server for testing with mock transports.
+func newTestServer(t *testing.T, backends map[string]*mockTransport) *Server {
+	t.Helper()
+
+	backendConfigs := make(map[string]*config.MCPClientConfig, len(backends))
+	for name := range backends {
+		backendConfigs[name] = &config.MCPClientConfig{
+			TransportType: config.MCPClientTypeSSE,
+			URL:           "http://localhost/" + name,
+		}
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		for name, mock := range backends {
+			if conf.URL == "http://localhost/"+name {
+				return mock, nil
+			}
+		}
+		return nil, fmt.Errorf("unknown backend")
+	}
+
+	getUserToken := func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+		return "", nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:            "test-aggregate",
+		TransportType:   config.MCPClientTypeSSE,
+		Backends:        backendConfigs,
+		Discovery:       &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second},
+		GetUserToken:    getUserToken,
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() {
+		_ = srv.Shutdown(context.Background())
+	})
+	return srv
+}
+
+func TestDiscoverTools(t *testing.T) {
+	pgTools := []mcp.Tool{
+		{Name: "query", Description: "Run SQL query"},
+		{Name: "tables", Description: "List tables"},
+	}
+	linearTools := []mcp.Tool{
+		{Name: "create_issue", Description: "Create issue"},
+	}
+
+	backends := map[string]*mockTransport{
+		"postgres": {tools: pgTools},
+		"linear":   {tools: linearTools},
+	}
+
+	srv := newTestServer(t, backends)
+
+	tools, err := srv.getTools(context.Background(), "user@test.com")
+	require.NoError(t, err)
+
+	totalTools := 0
+	for _, bt := range tools {
+		totalTools += len(bt)
+	}
+	assert.Equal(t, 3, totalTools)
+	assert.Len(t, tools["postgres"], 2)
+	assert.Len(t, tools["linear"], 1)
+	assert.Equal(t, "Run SQL query", tools["postgres"][0].Description)
+}
+
+func TestDiscoverToolsCaching(t *testing.T) {
+	var callCount atomic.Int32
+
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"postgres": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/postgres"},
+	}
+
+	mock := &mockTransport{tools: []mcp.Tool{{Name: "query"}}}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		callCount.Add(1)
+		return mock, nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	_, err := srv.getTools(context.Background(), "user@test.com")
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), callCount.Load())
+
+	_, err = srv.getTools(context.Background(), "other@test.com")
+	require.NoError(t, err)
+	// Second call uses cache — no new transport created
+	assert.Equal(t, int32(1), callCount.Load())
+}
+
+func TestDiscoverToolsTimeout(t *testing.T) {
+	backends := map[string]*mockTransport{
+		"fast": {tools: []mcp.Tool{{Name: "fast_tool"}}},
+		"slow": {tools: []mcp.Tool{{Name: "slow_tool"}}, initDelay: 10 * time.Second},
+	}
+
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"fast": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/fast"},
+		"slow": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/slow"},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		for name, mock := range backends {
+			if conf.URL == "http://localhost/"+name {
+				return mock, nil
+			}
+		}
+		return nil, fmt.Errorf("unknown backend")
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 100 * time.Millisecond, CacheTTL: 60 * time.Second},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	tools, err := srv.getTools(context.Background(), "user@test.com")
+	require.NoError(t, err)
+	assert.Contains(t, tools, "fast")
+	assert.NotContains(t, tools, "slow")
+}
+
+func TestToolRouting(t *testing.T) {
+	var calledWithName string
+	pgMock := &mockTransport{
+		tools: []mcp.Tool{{Name: "query"}},
+		callToolFn: func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			calledWithName = req.Params.Name
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.NewTextContent("result")},
+			}, nil
+		},
+	}
+
+	backends := map[string]*mockTransport{
+		"postgres": pgMock,
+	}
+
+	srv := newTestServer(t, backends)
+
+	handler := srv.makeToolHandler("user@test.com", "postgres")
+	result, err := handler(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "postgres.query",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "query", calledWithName)
+	assert.Len(t, result.Content, 1)
+}
+
+func TestPerUserConnectionIsolation(t *testing.T) {
+	var connCount atomic.Int32
+
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"postgres": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/postgres"},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		connCount.Add(1)
+		return &mockTransport{
+			tools: []mcp.Tool{{Name: "query"}},
+		}, nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	conn1, err := srv.getOrCreateConn(context.Background(), "alice@test.com", "postgres")
+	require.NoError(t, err)
+
+	conn2, err := srv.getOrCreateConn(context.Background(), "bob@test.com", "postgres")
+	require.NoError(t, err)
+
+	assert.NotSame(t, conn1, conn2)
+	assert.Equal(t, int32(2), connCount.Load())
+}
+
+func TestConnectionReuse(t *testing.T) {
+	var connCount atomic.Int32
+
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"postgres": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/postgres"},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		connCount.Add(1)
+		return &mockTransport{
+			tools: []mcp.Tool{{Name: "query"}},
+		}, nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	conn1, err := srv.getOrCreateConn(context.Background(), "alice@test.com", "postgres")
+	require.NoError(t, err)
+
+	conn2, err := srv.getOrCreateConn(context.Background(), "alice@test.com", "postgres")
+	require.NoError(t, err)
+
+	assert.Same(t, conn1, conn2)
+	assert.Equal(t, int32(1), connCount.Load())
+}
+
+func TestShutdownClosesConnections(t *testing.T) {
+	mock := &mockTransport{
+		tools: []mcp.Tool{{Name: "query"}},
+	}
+
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"postgres": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/postgres"},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		return mock, nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+
+	_, err := srv.getOrCreateConn(context.Background(), "user@test.com", "postgres")
+	require.NoError(t, err)
+
+	err = srv.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, mock.isClosed())
+}
+
+func TestToolFilter(t *testing.T) {
+	pgMock := &mockTransport{
+		tools: []mcp.Tool{
+			{Name: "query"},
+			{Name: "dangerous_drop"},
+			{Name: "tables"},
+		},
+	}
+
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"postgres": {
+			TransportType: config.MCPClientTypeSSE,
+			URL:           "http://localhost/postgres",
+			Options: &config.Options{
+				ToolFilter: &config.ToolFilterConfig{
+					Mode: config.ToolFilterModeBlock,
+					List: []string{"dangerous_drop"},
+				},
+			},
+		},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		return pgMock, nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	tools, err := srv.getTools(context.Background(), "user@test.com")
+	require.NoError(t, err)
+
+	pgTools := tools["postgres"]
+	names := make([]string, len(pgTools))
+	for i, tool := range pgTools {
+		names[i] = tool.Name
+	}
+
+	assert.Contains(t, names, "query")
+	assert.Contains(t, names, "tables")
+	assert.NotContains(t, names, "dangerous_drop")
+}
+
+func TestDiscoverySurvivesCallerCancellation(t *testing.T) {
+	initStarted := make(chan struct{})
+	initProceed := make(chan struct{})
+
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"postgres": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/postgres"},
+	}
+
+	var factoryCalls atomic.Int32
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		factoryCalls.Add(1)
+		return &slowInitTransport{
+			mockTransport: &mockTransport{
+				tools: []mcp.Tool{{Name: "query"}},
+			},
+			initStarted: initStarted,
+			initProceed: initProceed,
+		}, nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	callerCtx, callerCancel := context.WithCancel(context.Background())
+
+	type toolResult struct {
+		tools map[string][]mcp.Tool
+		err   error
+	}
+	caller1Done := make(chan toolResult, 1)
+	caller2Done := make(chan toolResult, 1)
+
+	go func() {
+		tools, err := srv.getTools(callerCtx, "user1@test.com")
+		caller1Done <- toolResult{tools, err}
+	}()
+	go func() {
+		tools, err := srv.getTools(context.Background(), "user2@test.com")
+		caller2Done <- toolResult{tools, err}
+	}()
+
+	<-initStarted
+	callerCancel()
+	close(initProceed)
+
+	r1 := <-caller1Done
+	r2 := <-caller2Done
+
+	// Both should succeed — context.WithoutCancel prevents caller1's
+	// cancellation from killing the shared singleflight discovery.
+	require.NoError(t, r2.err, "caller2 with Background context should succeed")
+	assert.Len(t, r2.tools["postgres"], 1)
+
+	// caller1 also succeeds because WithoutCancel detaches cancellation
+	require.NoError(t, r1.err, "caller1 should also succeed (singleflight shares result)")
+	assert.Len(t, r1.tools["postgres"], 1)
+
+	// Only one transport should have been created (singleflight dedup)
+	assert.Equal(t, int32(1), factoryCalls.Load())
+}
+
+func TestConcurrentGetOrCreateConn(t *testing.T) {
+	var factoryCalls atomic.Int32
+
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"postgres": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/postgres"},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		factoryCalls.Add(1)
+		return &mockTransport{
+			tools: []mcp.Tool{{Name: "query"}},
+		}, nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	conns := make([]*conn, goroutines)
+	errs := make([]error, goroutines)
+
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			conns[i], errs[i] = srv.getOrCreateConn(context.Background(), "alice@test.com", "postgres")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "goroutine %d failed", i)
+	}
+	for i := 1; i < goroutines; i++ {
+		assert.Same(t, conns[0], conns[i], "all goroutines should get the same conn")
+	}
+	assert.Equal(t, int32(1), factoryCalls.Load(), "singleflight should create exactly one transport")
+}
+
+func TestDoubleShutdown(t *testing.T) {
+	backends := map[string]*mockTransport{
+		"postgres": {tools: []mcp.Tool{{Name: "query"}}},
+	}
+	srv := newTestServer(t, backends)
+
+	err := srv.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	// Second shutdown must not panic
+	err = srv.Shutdown(context.Background())
+	require.NoError(t, err)
+}
+
+func TestAllBackendsFail(t *testing.T) {
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"broken": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/broken"},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		return nil, fmt.Errorf("connection refused")
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	_, err := srv.getTools(context.Background(), "user@test.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all backends failed")
+}
+
+func TestEvictConnOnListToolsFailure(t *testing.T) {
+	var factoryCalls atomic.Int32
+	var failOnList atomic.Bool
+	failOnList.Store(true)
+
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"postgres": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/postgres"},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		factoryCalls.Add(1)
+		mock := &mockTransport{
+			tools: []mcp.Tool{{Name: "query"}},
+		}
+		if failOnList.Load() {
+			mock.listToolsErr = fmt.Errorf("connection reset")
+		}
+		return mock, nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	// First discovery: ListTools fails, connection should be evicted
+	_, err := srv.getTools(context.Background(), "user@test.com")
+	require.Error(t, err)
+	assert.Equal(t, int32(1), factoryCalls.Load())
+
+	// Verify connection was evicted from the pool
+	srv.connMu.RLock()
+	_, exists := srv.conns[connKey{userEmail: "user@test.com", backendName: "postgres"}]
+	srv.connMu.RUnlock()
+	assert.False(t, exists, "broken connection should have been evicted")
+
+	// Fix the backend and retry — should create a new connection
+	failOnList.Store(false)
+	tools, err := srv.getTools(context.Background(), "user@test.com")
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), factoryCalls.Load(), "should have created a fresh connection")
+	assert.Len(t, tools["postgres"], 1)
+}
+
+func TestEvictConnOnCallToolFailure(t *testing.T) {
+	var callCount atomic.Int32
+	pgMock := &mockTransport{
+		tools: []mcp.Tool{{Name: "query"}},
+		callToolFn: func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return nil, fmt.Errorf("connection reset")
+			}
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.NewTextContent("ok")},
+			}, nil
+		},
+	}
+
+	backends := map[string]*mockTransport{
+		"postgres": pgMock,
+	}
+	srv := newTestServer(t, backends)
+
+	handler := srv.makeToolHandler("user@test.com", "postgres")
+
+	// First call fails with transport error — connection should be evicted
+	_, err := handler(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "postgres.query"},
+	})
+	require.Error(t, err)
+
+	// Verify eviction happened
+	srv.connMu.RLock()
+	_, exists := srv.conns[connKey{userEmail: "user@test.com", backendName: "postgres"}]
+	srv.connMu.RUnlock()
+	assert.False(t, exists, "broken connection should have been evicted")
+}
+
+func TestGetUserTokenFailureDegradation(t *testing.T) {
+	mock := &mockTransport{
+		tools: []mcp.Tool{{Name: "query"}},
+	}
+
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"postgres": {
+			TransportType:     config.MCPClientTypeSSE,
+			URL:               "http://localhost/postgres",
+			RequiresUserToken: true,
+		},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		return mock, nil
+	}
+
+	var tokenCallCount atomic.Int32
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			tokenCallCount.Add(1)
+			return "", fmt.Errorf("token store unavailable")
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	// Connection should succeed despite token failure — createConn logs
+	// the warning and proceeds without the token.
+	c, err := srv.getOrCreateConn(context.Background(), "user@test.com", "postgres")
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+	assert.Equal(t, int32(1), tokenCallCount.Load())
+
+	// The connection should be functional
+	assert.True(t, mock.started)
+}
+
+func TestShutdownDuringActiveToolCall(t *testing.T) {
+	toolStarted := make(chan struct{})
+
+	pgMock := newMockTransport([]mcp.Tool{{Name: "query"}})
+	pgMock.callToolFn = func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		close(toolStarted)
+		// Block until the transport is closed (simulating real behavior where
+		// closing the underlying HTTP connection interrupts in-flight requests)
+		// or the caller context is done.
+		select {
+		case <-pgMock.closeCh:
+			return nil, fmt.Errorf("transport closed")
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"postgres": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/postgres"},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		return pgMock, nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+
+	// Establish connection first
+	_, err := srv.getOrCreateConn(context.Background(), "user@test.com", "postgres")
+	require.NoError(t, err)
+
+	// Start a tool call that blocks
+	handler := srv.makeToolHandler("user@test.com", "postgres")
+	type callResult struct {
+		result *mcp.CallToolResult
+		err    error
+	}
+	done := make(chan callResult, 1)
+	go func() {
+		r, err := handler(context.Background(), mcp.CallToolRequest{
+			Params: mcp.CallToolParams{Name: "postgres.query"},
+		})
+		done <- callResult{r, err}
+	}()
+
+	// Wait for tool call to be in-flight
+	<-toolStarted
+
+	// Shutdown while tool call is active — Close() on the transport
+	// closes closeCh, which unblocks the in-flight CallTool.
+	shutdownErr := srv.Shutdown(context.Background())
+	require.NoError(t, shutdownErr)
+
+	// The in-flight tool call should complete with an error
+	result := <-done
+	assert.Error(t, result.err, "in-flight tool call should fail after shutdown")
+}
+
+func TestCacheExpiryAndRediscovery(t *testing.T) {
+	mock := &mockTransport{
+		tools: []mcp.Tool{{Name: "query"}},
+	}
+
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"postgres": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/postgres"},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		return mock, nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 50 * time.Millisecond},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	// First discovery
+	tools, err := srv.getTools(context.Background(), "user@test.com")
+	require.NoError(t, err)
+	assert.Len(t, tools["postgres"], 1)
+	assert.Equal(t, "query", tools["postgres"][0].Name)
+
+	// Simulate backend adding a new tool — mutate the mock directly so the
+	// existing connection (reused on rediscovery) returns updated tools.
+	mock.mu.Lock()
+	mock.tools = []mcp.Tool{
+		{Name: "query"},
+		{Name: "tables"},
+	}
+	mock.mu.Unlock()
+
+	// Wait for cache to expire
+	time.Sleep(100 * time.Millisecond)
+
+	// Rediscovery should pick up the new tool
+	tools, err = srv.getTools(context.Background(), "user@test.com")
+	require.NoError(t, err)
+	assert.Len(t, tools["postgres"], 2)
+}
+
+func TestMaxConnsPerUser(t *testing.T) {
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"backend1": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/backend1"},
+		"backend2": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/backend2"},
+		"backend3": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/backend3"},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		return &mockTransport{tools: []mcp.Tool{{Name: "tool"}}}, nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second, MaxConnsPerUser: 2},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	_, err := srv.getOrCreateConn(context.Background(), "alice@test.com", "backend1")
+	require.NoError(t, err)
+	_, err = srv.getOrCreateConn(context.Background(), "alice@test.com", "backend2")
+	require.NoError(t, err)
+
+	// Third connection exceeds limit
+	_, err = srv.getOrCreateConn(context.Background(), "alice@test.com", "backend3")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUserConnLimitExceeded)
+
+	// Different user is unaffected
+	_, err = srv.getOrCreateConn(context.Background(), "bob@test.com", "backend1")
+	require.NoError(t, err)
+}
+
+func TestMaxConnsPerUserZeroUnlimited(t *testing.T) {
+	backendConfigs := map[string]*config.MCPClientConfig{
+		"b1": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/b1"},
+		"b2": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/b2"},
+		"b3": {TransportType: config.MCPClientTypeSSE, URL: "http://localhost/b3"},
+	}
+
+	factory := func(conf *config.MCPClientConfig) (client.MCPClientInterface, error) {
+		return &mockTransport{tools: []mcp.Tool{{Name: "tool"}}}, nil
+	}
+
+	srv := NewServer(ServerConfig{
+		Name:          "test-aggregate",
+		TransportType: config.MCPClientTypeSSE,
+		Backends:      backendConfigs,
+		Discovery:     &config.DiscoveryConfig{Timeout: 5 * time.Second, CacheTTL: 60 * time.Second, MaxConnsPerUser: 0},
+		GetUserToken: func(ctx context.Context, userEmail, serviceName string, serviceConfig *config.MCPClientConfig) (string, error) {
+			return "", nil
+		},
+		CreateTransport: factory,
+		BaseURL:         "http://localhost:8080",
+	})
+	srv.Start()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	for _, name := range []string{"b1", "b2", "b3"} {
+		_, err := srv.getOrCreateConn(context.Background(), "alice@test.com", name)
+		require.NoError(t, err, "connection to %s should succeed with unlimited pool", name)
+	}
+}

--- a/internal/client/session_manager.go
+++ b/internal/client/session_manager.go
@@ -120,10 +120,14 @@ func NewStdioSessionManager(opts ...SessionManagerOption) *StdioSessionManager {
 		opt(sm)
 	}
 
+	return sm
+}
+
+// Start begins the background cleanup routine. Must be called after construction.
+// The cleanup routine is stopped by Shutdown.
+func (sm *StdioSessionManager) Start() {
 	sm.wg.Add(1)
 	go sm.startCleanupRoutine()
-
-	return sm
 }
 
 // GetOrCreateSession returns existing session or creates new one
@@ -533,24 +537,26 @@ func (sm *StdioSessionManager) startCleanupRoutine() {
 	}
 }
 
-// cleanupTimedOutSessions removes sessions that have timed out
+// cleanupTimedOutSessions removes sessions that have timed out.
+// Uses a single write lock to atomically check freshness and remove, preventing
+// a TOCTOU race where a session could be accessed between the scan and removal.
 func (sm *StdioSessionManager) cleanupTimedOutSessions() {
 	now := time.Now()
 
-	// Find timed out sessions
-	sm.mu.RLock()
-	timedOut := make([]SessionKey, 0)
+	sm.mu.Lock()
+	var timedOut []*StdioSession
+	var timedOutKeys []SessionKey
 	totalSessions := len(sm.sessions)
-	activeSessions := 0
 	for key, session := range sm.sessions {
 		lastAccessed := session.lastAccessed.Load()
 		if lastAccessed != nil && now.Sub(*lastAccessed) > sm.defaultTimeout {
-			timedOut = append(timedOut, key)
-		} else {
-			activeSessions++
+			timedOutKeys = append(timedOutKeys, key)
+			timedOut = append(timedOut, session)
+			delete(sm.sessions, key)
 		}
 	}
-	sm.mu.RUnlock()
+	activeSessions := len(sm.sessions)
+	sm.mu.Unlock()
 
 	if totalSessions > 0 || len(timedOut) > 0 {
 		log.LogTraceWithFields("session_manager", "Session cleanup cycle", map[string]any{
@@ -561,15 +567,17 @@ func (sm *StdioSessionManager) cleanupTimedOutSessions() {
 		})
 	}
 
-	for _, key := range timedOut {
+	for i, session := range timedOut {
+		key := timedOutKeys[i]
 		log.LogInfoWithFields("session_manager", "Removing timed out session", map[string]any{
 			"sessionID": key.SessionID,
 			"server":    key.ServerName,
 			"user":      key.UserEmail,
 			"timeout":   sm.defaultTimeout,
 		})
-		if err := sm.RemoveSession(key); err != nil {
-			log.LogErrorWithFields("session_cleanup", "Failed to remove timed out session", map[string]any{
+		session.cancel()
+		if err := session.client.Close(); err != nil {
+			log.LogErrorWithFields("session_cleanup", "Failed to close timed out session", map[string]any{
 				"sessionID": key.SessionID,
 				"server":    key.ServerName,
 				"user":      key.UserEmail,

--- a/internal/client/session_manager_test.go
+++ b/internal/client/session_manager_test.go
@@ -25,6 +25,7 @@ func TestStdioSessionManager_CreateAndRetrieve(t *testing.T) {
 		WithClientCreator(mockCreator),
 		WithTimeout(1*time.Minute),
 	)
+	sm.Start()
 	defer sm.Shutdown()
 
 	key := SessionKey{
@@ -73,6 +74,7 @@ func TestStdioSessionManager_UserLimits(t *testing.T) {
 		WithClientCreator(mockCreator),
 		WithMaxPerUser(2),
 	)
+	sm.Start()
 	defer sm.Shutdown()
 
 	userEmail := "test@example.com"
@@ -110,6 +112,7 @@ func TestStdioSessionManager_RemoveSession(t *testing.T) {
 	}
 
 	sm := NewStdioSessionManager(WithClientCreator(mockCreator))
+	sm.Start()
 	defer sm.Shutdown()
 
 	key := SessionKey{
@@ -150,6 +153,7 @@ func TestStdioSessionManager_Timeout(t *testing.T) {
 		WithTimeout(100*time.Millisecond),
 		WithCleanupInterval(50*time.Millisecond),
 	)
+	sm.Start()
 	defer sm.Shutdown()
 
 	key := SessionKey{
@@ -186,6 +190,7 @@ func TestStdioSessionManager_ConcurrentAccess(t *testing.T) {
 	}
 
 	sm := NewStdioSessionManager(WithClientCreator(mockCreator))
+	sm.Start()
 	defer sm.Shutdown()
 
 	config := &config.MCPClientConfig{Command: "echo"}
@@ -232,6 +237,7 @@ func TestStdioSessionManager_NoLimitsForAnonymous(t *testing.T) {
 		WithClientCreator(mockCreator),
 		WithMaxPerUser(1), // Very low limit
 	)
+	sm.Start()
 	defer sm.Shutdown()
 
 	config := &config.MCPClientConfig{Command: "echo"}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -5,10 +5,18 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/dgellow/mcp-front/internal/log"
 )
+
+var validServerNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+func isValidServerName(name string) bool {
+	return validServerNameRe.MatchString(name)
+}
 
 // Load loads and processes the config with immediate env var resolution
 func Load(path string) (Config, error) {
@@ -45,6 +53,8 @@ func Load(path string) (Config, error) {
 	if err := extractBasePath(&config); err != nil {
 		return Config{}, fmt.Errorf("extracting base path: %w", err)
 	}
+
+	ResolveDefaults(&config)
 
 	if err := ValidateConfig(&config); err != nil {
 		return Config{}, fmt.Errorf("config validation failed: %w", err)
@@ -108,7 +118,30 @@ func validateRawConfig(rawConfig map[string]any) error {
 	return nil
 }
 
-// ValidateConfig validates the resolved configuration
+// ResolveDefaults fills in default values that depend on the full config.
+// This is pure transformation — no validation. Must be called before ValidateConfig.
+func ResolveDefaults(config *Config) {
+	// Collect servers eligible for aggregate defaults: non-aggregate,
+	// non-inline (inline servers have no network transport).
+	eligibleNames := make([]string, 0)
+	for name, server := range config.MCPServers {
+		if !server.IsAggregate() && server.TransportType != MCPClientTypeInline {
+			eligibleNames = append(eligibleNames, name)
+		}
+	}
+	sort.Strings(eligibleNames)
+
+	for _, server := range config.MCPServers {
+		if server.IsAggregate() && server.Servers == nil {
+			serversCopy := make([]string, len(eligibleNames))
+			copy(serversCopy, eligibleNames)
+			server.Servers = serversCopy
+		}
+	}
+}
+
+// ValidateConfig validates the resolved configuration.
+// ResolveDefaults must be called first to fill in computed defaults.
 func ValidateConfig(config *Config) error {
 	if config.Proxy.BaseURL == "" {
 		return fmt.Errorf("proxy.baseURL is required")
@@ -125,12 +158,61 @@ func ValidateConfig(config *Config) error {
 
 	hasOAuth := config.Proxy.Auth != nil
 
+	aggregateNames := make(map[string]bool)
 	for name, server := range config.MCPServers {
+		if server.IsAggregate() {
+			aggregateNames[name] = true
+		}
+	}
+
+	for name, server := range config.MCPServers {
+		if !isValidServerName(name) {
+			return fmt.Errorf("server name '%s' is invalid (must start with alphanumeric, then alphanumeric/underscore/hyphen only)", name)
+		}
+
 		if err := validateMCPServer(name, server); err != nil {
 			return err
 		}
 
-		// Validate that user tokens require OAuth
+		if server.IsAggregate() {
+			if len(server.Servers) == 0 {
+				return fmt.Errorf("aggregate server '%s' has no servers (configure servers list or add non-aggregate servers)", name)
+			}
+			seen := make(map[string]bool, len(server.Servers))
+			for _, ref := range server.Servers {
+				if seen[ref] {
+					return fmt.Errorf("aggregate server '%s' has duplicate reference '%s'", name, ref)
+				}
+				seen[ref] = true
+				if ref == name {
+					return fmt.Errorf("aggregate server '%s' cannot reference itself", name)
+				}
+				if aggregateNames[ref] {
+					return fmt.Errorf("aggregate server '%s' cannot reference another aggregate '%s'", name, ref)
+				}
+				refServer, exists := config.MCPServers[ref]
+				if !exists {
+					return fmt.Errorf("aggregate server '%s' references nonexistent server '%s'", name, ref)
+				}
+				if refServer.TransportType == MCPClientTypeInline {
+					return fmt.Errorf("aggregate server '%s' cannot reference inline server '%s' (inline servers have no network transport)", name, ref)
+				}
+				if refServer.TransportType == MCPClientTypeStdio {
+					log.LogWarnWithFields("config", "Aggregate references stdio backend — this spawns a long-lived process per user", map[string]any{
+						"aggregate": name,
+						"backend":   ref,
+					})
+				}
+			}
+			if server.Discovery.Timeout >= server.Discovery.CacheTTL {
+				log.LogWarnWithFields("config", "Discovery timeout >= cacheTTL: discovery may not complete before cache expires", map[string]any{
+					"aggregate": name,
+					"timeout":   server.Discovery.Timeout,
+					"cacheTTL":  server.Discovery.CacheTTL,
+				})
+			}
+		}
+
 		if server.RequiresUserToken && !hasOAuth {
 			return fmt.Errorf("server %s requires user tokens but OAuth is not configured - user tokens require OAuth authentication", name)
 		}
@@ -225,6 +307,16 @@ func validateOAuthConfig(oauth *OAuthAuthConfig) error {
 }
 
 func validateMCPServer(name string, server *MCPClientConfig) error {
+	if server.IsAggregate() {
+		if server.TransportType != MCPClientTypeSSE && server.TransportType != MCPClientTypeStreamable {
+			return fmt.Errorf("aggregate server %s must use 'sse' or 'streamable-http' transport, got '%s'", name, server.TransportType)
+		}
+		if server.Discovery == nil {
+			return fmt.Errorf("aggregate server %s is missing discovery configuration", name)
+		}
+		return nil
+	}
+
 	// Transport type is required
 	if server.TransportType == "" {
 		return fmt.Errorf("server %s must specify transportType (stdio, sse, streamable-http, or inline)", name)
@@ -262,6 +354,28 @@ func validateMCPServer(name string, server *MCPClientConfig) error {
 		return fmt.Errorf("server %s requires user token but has no userAuthentication", name)
 	}
 
+	// Validate tool filter configuration
+	if err := validateToolFilter(name, server); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateToolFilter(name string, server *MCPClientConfig) error {
+	if server.Options == nil || server.Options.ToolFilter == nil {
+		return nil
+	}
+	filter := server.Options.ToolFilter
+	if len(filter.List) > 0 && filter.Mode == "" {
+		return fmt.Errorf("server %s has toolFilter list but no mode (must specify 'allow' or 'block')", name)
+	}
+	if filter.Mode != "" {
+		mode := ToolFilterMode(strings.ToLower(string(filter.Mode)))
+		if mode != ToolFilterModeAllow && mode != ToolFilterModeBlock {
+			return fmt.Errorf("server %s has invalid toolFilter mode '%s' (must be 'allow' or 'block')", name, filter.Mode)
+		}
+	}
 	return nil
 }
 

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -241,6 +241,397 @@ func TestValidateConfig_SessionConfig(t *testing.T) {
 	}
 }
 
+func TestValidateConfig_AggregateServer(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *Config
+		expectError string
+	}{
+		{
+			name: "aggregate_defaults_servers_to_all_non_aggregates",
+			config: &Config{
+				Proxy: ProxyConfig{
+					BaseURL: "https://test.example.com",
+					Addr:    ":8080",
+				},
+				MCPServers: map[string]*MCPClientConfig{
+					"postgres": {
+						Type:          ServerTypeDirect,
+						TransportType: MCPClientTypeSSE,
+						URL:           "http://localhost:5432",
+					},
+					"linear": {
+						Type:          ServerTypeDirect,
+						TransportType: MCPClientTypeSSE,
+						URL:           "http://localhost:3000",
+					},
+					"mcp": {
+						Type:          ServerTypeAggregate,
+						TransportType: MCPClientTypeSSE,
+						Discovery:     &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second},
+					},
+				},
+			},
+		},
+		{
+			name: "aggregate_self_reference",
+			config: &Config{
+				Proxy: ProxyConfig{
+					BaseURL: "https://test.example.com",
+					Addr:    ":8080",
+				},
+				MCPServers: map[string]*MCPClientConfig{
+					"mcp": {
+						Type:          ServerTypeAggregate,
+						TransportType: MCPClientTypeSSE,
+						Discovery:     &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second},
+						Servers:       []string{"mcp"},
+					},
+				},
+			},
+			expectError: "cannot reference itself",
+		},
+		{
+			name: "aggregate_references_nonexistent",
+			config: &Config{
+				Proxy: ProxyConfig{
+					BaseURL: "https://test.example.com",
+					Addr:    ":8080",
+				},
+				MCPServers: map[string]*MCPClientConfig{
+					"mcp": {
+						Type:          ServerTypeAggregate,
+						TransportType: MCPClientTypeSSE,
+						Discovery:     &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second},
+						Servers:       []string{"ghost"},
+					},
+				},
+			},
+			expectError: "references nonexistent server",
+		},
+		{
+			name: "aggregate_invalid_transport",
+			config: &Config{
+				Proxy: ProxyConfig{
+					BaseURL: "https://test.example.com",
+					Addr:    ":8080",
+				},
+				MCPServers: map[string]*MCPClientConfig{
+					"mcp": {
+						Type:          ServerTypeAggregate,
+						TransportType: MCPClientTypeStdio,
+						Discovery:     &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second},
+					},
+				},
+			},
+			expectError: "must use 'sse' or 'streamable-http'",
+		},
+		{
+			name: "aggregate_references_inline_server",
+			config: &Config{
+				Proxy: ProxyConfig{
+					BaseURL: "https://test.example.com",
+					Addr:    ":8080",
+				},
+				MCPServers: map[string]*MCPClientConfig{
+					"tools": {
+						Type:          ServerTypeDirect,
+						TransportType: MCPClientTypeInline,
+						InlineConfig:  []byte(`{"tools":[]}`),
+					},
+					"mcp": {
+						Type:          ServerTypeAggregate,
+						TransportType: MCPClientTypeSSE,
+						Discovery:     &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second},
+						Servers:       []string{"tools"},
+					},
+				},
+			},
+			expectError: "cannot reference inline server",
+		},
+		{
+			name: "aggregate_nil_discovery",
+			config: &Config{
+				Proxy: ProxyConfig{
+					BaseURL: "https://test.example.com",
+					Addr:    ":8080",
+				},
+				MCPServers: map[string]*MCPClientConfig{
+					"postgres": {
+						Type:          ServerTypeDirect,
+						TransportType: MCPClientTypeSSE,
+						URL:           "http://localhost:5432",
+					},
+					"mcp": {
+						Type:          ServerTypeAggregate,
+						TransportType: MCPClientTypeSSE,
+						Servers:       []string{"postgres"},
+					},
+				},
+			},
+			expectError: "missing discovery configuration",
+		},
+		{
+			name: "aggregate_explicit_empty_servers",
+			config: &Config{
+				Proxy: ProxyConfig{
+					BaseURL: "https://test.example.com",
+					Addr:    ":8080",
+				},
+				MCPServers: map[string]*MCPClientConfig{
+					"postgres": {
+						Type:          ServerTypeDirect,
+						TransportType: MCPClientTypeSSE,
+						URL:           "http://localhost:5432",
+					},
+					"mcp": {
+						Type:          ServerTypeAggregate,
+						TransportType: MCPClientTypeSSE,
+						Servers:       []string{},
+						Discovery:     &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second},
+					},
+				},
+			},
+			expectError: "has no servers",
+		},
+		{
+			name: "server_name_with_dot",
+			config: &Config{
+				Proxy: ProxyConfig{BaseURL: "https://test.example.com", Addr: ":8080"},
+				MCPServers: map[string]*MCPClientConfig{
+					"my.server": {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432"},
+				},
+			},
+			expectError: "is invalid",
+		},
+		{
+			name: "server_name_with_slash",
+			config: &Config{
+				Proxy: ProxyConfig{BaseURL: "https://test.example.com", Addr: ":8080"},
+				MCPServers: map[string]*MCPClientConfig{
+					"foo/bar": {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432"},
+				},
+			},
+			expectError: "is invalid",
+		},
+		{
+			name: "server_name_with_space",
+			config: &Config{
+				Proxy: ProxyConfig{BaseURL: "https://test.example.com", Addr: ":8080"},
+				MCPServers: map[string]*MCPClientConfig{
+					"my server": {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432"},
+				},
+			},
+			expectError: "is invalid",
+		},
+		{
+			name: "server_name_starting_with_hyphen",
+			config: &Config{
+				Proxy: ProxyConfig{BaseURL: "https://test.example.com", Addr: ":8080"},
+				MCPServers: map[string]*MCPClientConfig{
+					"-postgres": {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432"},
+				},
+			},
+			expectError: "is invalid",
+		},
+		{
+			name: "valid_server_name_with_hyphen_and_underscore",
+			config: &Config{
+				Proxy: ProxyConfig{BaseURL: "https://test.example.com", Addr: ":8080"},
+				MCPServers: map[string]*MCPClientConfig{
+					"my-server_01": {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432"},
+				},
+			},
+		},
+		{
+			name: "aggregate_duplicate_reference",
+			config: &Config{
+				Proxy: ProxyConfig{BaseURL: "https://test.example.com", Addr: ":8080"},
+				MCPServers: map[string]*MCPClientConfig{
+					"postgres": {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432"},
+					"mcp": {
+						Type: ServerTypeAggregate, TransportType: MCPClientTypeSSE,
+						Discovery: &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second},
+						Servers:   []string{"postgres", "postgres"},
+					},
+				},
+			},
+			expectError: "duplicate reference 'postgres'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ResolveDefaults(tt.config)
+			err := ValidateConfig(tt.config)
+			if tt.expectError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestResolveDefaults(t *testing.T) {
+	t.Run("fills_aggregate_servers_with_all_non_aggregates", func(t *testing.T) {
+		cfg := &Config{
+			MCPServers: map[string]*MCPClientConfig{
+				"postgres": {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432"},
+				"linear":   {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:3000"},
+				"mcp":      {Type: ServerTypeAggregate, TransportType: MCPClientTypeSSE, Discovery: &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second}},
+			},
+		}
+		ResolveDefaults(cfg)
+
+		mcp := cfg.MCPServers["mcp"]
+		assert.Equal(t, []string{"linear", "postgres"}, mcp.Servers)
+	})
+
+	t.Run("does_not_override_explicit_servers", func(t *testing.T) {
+		cfg := &Config{
+			MCPServers: map[string]*MCPClientConfig{
+				"postgres": {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432"},
+				"linear":   {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:3000"},
+				"mcp":      {Type: ServerTypeAggregate, TransportType: MCPClientTypeSSE, Servers: []string{"postgres"}, Discovery: &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second}},
+			},
+		}
+		ResolveDefaults(cfg)
+
+		mcp := cfg.MCPServers["mcp"]
+		assert.Equal(t, []string{"postgres"}, mcp.Servers)
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		cfg := &Config{
+			MCPServers: map[string]*MCPClientConfig{
+				"postgres": {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432"},
+				"mcp":      {Type: ServerTypeAggregate, TransportType: MCPClientTypeSSE, Discovery: &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second}},
+			},
+		}
+		ResolveDefaults(cfg)
+		first := cfg.MCPServers["mcp"].Servers
+
+		ResolveDefaults(cfg)
+		second := cfg.MCPServers["mcp"].Servers
+
+		assert.Equal(t, first, second)
+	})
+
+	t.Run("excludes_inline_from_defaults", func(t *testing.T) {
+		cfg := &Config{
+			MCPServers: map[string]*MCPClientConfig{
+				"postgres": {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432"},
+				"tools":    {Type: ServerTypeDirect, TransportType: MCPClientTypeInline, InlineConfig: []byte(`{"tools":[]}`)},
+				"mcp":      {Type: ServerTypeAggregate, TransportType: MCPClientTypeSSE, Discovery: &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second}},
+			},
+		}
+		ResolveDefaults(cfg)
+
+		mcp := cfg.MCPServers["mcp"]
+		assert.Equal(t, []string{"postgres"}, mcp.Servers)
+	})
+
+	t.Run("does_not_override_explicit_empty_servers", func(t *testing.T) {
+		cfg := &Config{
+			MCPServers: map[string]*MCPClientConfig{
+				"postgres": {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432"},
+				"mcp":      {Type: ServerTypeAggregate, TransportType: MCPClientTypeSSE, Servers: []string{}, Discovery: &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second}},
+			},
+		}
+		ResolveDefaults(cfg)
+
+		mcp := cfg.MCPServers["mcp"]
+		assert.Equal(t, []string{}, mcp.Servers)
+	})
+
+	t.Run("excludes_aggregates_from_defaults", func(t *testing.T) {
+		cfg := &Config{
+			MCPServers: map[string]*MCPClientConfig{
+				"postgres": {Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432"},
+				"agg1":     {Type: ServerTypeAggregate, TransportType: MCPClientTypeSSE, Discovery: &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second}},
+				"agg2":     {Type: ServerTypeAggregate, TransportType: MCPClientTypeSSE, Discovery: &DiscoveryConfig{Timeout: 10 * time.Second, CacheTTL: 60 * time.Second}},
+			},
+		}
+		ResolveDefaults(cfg)
+
+		assert.Equal(t, []string{"postgres"}, cfg.MCPServers["agg1"].Servers)
+		assert.Equal(t, []string{"postgres"}, cfg.MCPServers["agg2"].Servers)
+	})
+}
+
+func TestValidateConfig_ToolFilterMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *Config
+		expectError string
+	}{
+		{
+			name: "valid_allow_mode",
+			config: &Config{
+				Proxy: ProxyConfig{BaseURL: "https://test.example.com", Addr: ":8080"},
+				MCPServers: map[string]*MCPClientConfig{
+					"postgres": {
+						Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432",
+						Options: &Options{ToolFilter: &ToolFilterConfig{Mode: ToolFilterModeAllow, List: []string{"query"}}},
+					},
+				},
+			},
+		},
+		{
+			name: "valid_block_mode",
+			config: &Config{
+				Proxy: ProxyConfig{BaseURL: "https://test.example.com", Addr: ":8080"},
+				MCPServers: map[string]*MCPClientConfig{
+					"postgres": {
+						Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432",
+						Options: &Options{ToolFilter: &ToolFilterConfig{Mode: ToolFilterModeBlock, List: []string{"drop"}}},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid_mode",
+			config: &Config{
+				Proxy: ProxyConfig{BaseURL: "https://test.example.com", Addr: ":8080"},
+				MCPServers: map[string]*MCPClientConfig{
+					"postgres": {
+						Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432",
+						Options: &Options{ToolFilter: &ToolFilterConfig{Mode: "allowlist", List: []string{"query"}}},
+					},
+				},
+			},
+			expectError: "invalid toolFilter mode 'allowlist'",
+		},
+		{
+			name: "list_without_mode",
+			config: &Config{
+				Proxy: ProxyConfig{BaseURL: "https://test.example.com", Addr: ":8080"},
+				MCPServers: map[string]*MCPClientConfig{
+					"postgres": {
+						Type: ServerTypeDirect, TransportType: MCPClientTypeSSE, URL: "http://localhost:5432",
+						Options: &Options{ToolFilter: &ToolFilterConfig{List: []string{"query"}}},
+					},
+				},
+			},
+			expectError: "has toolFilter list but no mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateConfig(tt.config)
+			if tt.expectError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestExtractBasePath(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -37,6 +37,21 @@ const (
 	MCPClientTypeInline     MCPClientType = "inline"
 )
 
+// ServerType represents whether a server is a direct backend or an aggregate
+type ServerType string
+
+const (
+	ServerTypeDirect    ServerType = "direct"
+	ServerTypeAggregate ServerType = "aggregate"
+)
+
+// DiscoveryConfig configures tool discovery for aggregate servers
+type DiscoveryConfig struct {
+	Timeout         time.Duration
+	CacheTTL        time.Duration
+	MaxConnsPerUser int // 0 means unlimited
+}
+
 // AuthKind represents the type of authentication
 type AuthKind string
 
@@ -155,6 +170,7 @@ type UserAuthentication struct {
 // User token references using {"$userToken": "...{{token}}..."} follow the same
 // pattern but are resolved at request time with the authenticated user's token.
 type MCPClientConfig struct {
+	Type          ServerType    `json:"type,omitempty"`
 	TransportType MCPClientType `json:"transportType,omitempty"`
 
 	// Stdio
@@ -184,11 +200,20 @@ type MCPClientConfig struct {
 
 	// Inline MCP server configuration
 	InlineConfig json.RawMessage `json:"inline,omitempty"`
+
+	// Aggregate server configuration
+	Servers   []string         `json:"servers,omitempty"`
+	Discovery *DiscoveryConfig `json:"discovery,omitempty"`
 }
 
 // IsStdio returns true if this is a stdio-based MCP server
 func (c *MCPClientConfig) IsStdio() bool {
 	return c.TransportType == MCPClientTypeStdio
+}
+
+// IsAggregate returns true if this is an aggregate server
+func (c *MCPClientConfig) IsAggregate() bool {
+	return c.Type == ServerTypeAggregate
 }
 
 // SessionConfig represents session management configuration

--- a/internal/config/unmarshal.go
+++ b/internal/config/unmarshal.go
@@ -16,6 +16,7 @@ import (
 func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 	// Use a raw type to avoid recursion
 	type rawConfig struct {
+		Type               ServerType                 `json:"type,omitempty"`
 		TransportType      MCPClientType              `json:"transportType,omitempty"`
 		Command            json.RawMessage            `json:"command,omitempty"`
 		Args               []json.RawMessage          `json:"args,omitempty"`
@@ -28,11 +29,19 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 		UserAuthentication *UserAuthentication        `json:"userAuthentication,omitempty"`
 		ServiceAuths       []ServiceAuth              `json:"serviceAuths,omitempty"`
 		InlineConfig       json.RawMessage            `json:"inline,omitempty"`
+		Servers            []string                   `json:"servers,omitempty"`
+		Discovery          json.RawMessage            `json:"discovery,omitempty"`
 	}
 
 	var raw rawConfig
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
+	}
+
+	// Default type to "direct"
+	c.Type = raw.Type
+	if c.Type == "" {
+		c.Type = ServerTypeDirect
 	}
 
 	c.TransportType = raw.TransportType
@@ -41,6 +50,26 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 	c.UserAuthentication = raw.UserAuthentication
 	c.ServiceAuths = raw.ServiceAuths
 	c.InlineConfig = raw.InlineConfig
+
+	if c.Type == ServerTypeAggregate {
+		c.Servers = raw.Servers
+		if c.TransportType == "" {
+			c.TransportType = MCPClientTypeSSE
+		}
+		if raw.Discovery != nil {
+			disc, err := parseDiscoveryConfig(raw.Discovery)
+			if err != nil {
+				return fmt.Errorf("parsing discovery: %w", err)
+			}
+			c.Discovery = disc
+		} else {
+			c.Discovery = &DiscoveryConfig{
+				Timeout:  10 * time.Second,
+				CacheTTL: 60 * time.Second,
+			}
+		}
+		return nil
+	}
 
 	// Parse timeout if present
 	if raw.Timeout != "" {
@@ -108,6 +137,54 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// parseDiscoveryConfig parses discovery configuration with duration defaults
+func parseDiscoveryConfig(data json.RawMessage) (*DiscoveryConfig, error) {
+	var raw struct {
+		Timeout         string `json:"timeout"`
+		CacheTTL        string `json:"cacheTtl"`
+		MaxConnsPerUser *int   `json:"maxConnsPerUser"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+
+	disc := &DiscoveryConfig{
+		Timeout:  10 * time.Second,
+		CacheTTL: 60 * time.Second,
+	}
+
+	if raw.Timeout != "" {
+		d, err := time.ParseDuration(raw.Timeout)
+		if err != nil {
+			return nil, fmt.Errorf("parsing timeout: %w", err)
+		}
+		disc.Timeout = d
+	}
+	if raw.CacheTTL != "" {
+		d, err := time.ParseDuration(raw.CacheTTL)
+		if err != nil {
+			return nil, fmt.Errorf("parsing cacheTtl: %w", err)
+		}
+		disc.CacheTTL = d
+	}
+
+	if raw.MaxConnsPerUser != nil {
+		if *raw.MaxConnsPerUser < 0 {
+			return nil, fmt.Errorf("maxConnsPerUser cannot be negative")
+		}
+		disc.MaxConnsPerUser = *raw.MaxConnsPerUser
+	}
+
+	if disc.Timeout <= 0 {
+		return nil, fmt.Errorf("discovery timeout must be positive, got %s", disc.Timeout)
+	}
+	if disc.CacheTTL <= 0 {
+		return nil, fmt.Errorf("discovery cacheTtl must be positive, got %s", disc.CacheTTL)
+	}
+
+	return disc, nil
 }
 
 // UnmarshalJSON implements custom unmarshaling for OAuthAuthConfig

--- a/internal/config/unmarshal_test.go
+++ b/internal/config/unmarshal_test.go
@@ -436,3 +436,111 @@ func TestProxyConfig_SessionConfigIntegration(t *testing.T) {
 	assert.Equal(t, 15*time.Minute, config.Sessions.Timeout)
 	assert.Equal(t, 3*time.Minute, config.Sessions.CleanupInterval)
 }
+
+func TestMCPClientConfig_AggregateDefaults(t *testing.T) {
+	input := `{
+		"type": "aggregate",
+		"servers": ["postgres", "linear"]
+	}`
+
+	var cfg MCPClientConfig
+	err := json.Unmarshal([]byte(input), &cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, ServerTypeAggregate, cfg.Type)
+	assert.Equal(t, MCPClientTypeSSE, cfg.TransportType)
+	assert.Equal(t, []string{"postgres", "linear"}, cfg.Servers)
+	require.NotNil(t, cfg.Discovery)
+	assert.Equal(t, 10*time.Second, cfg.Discovery.Timeout)
+	assert.Equal(t, 60*time.Second, cfg.Discovery.CacheTTL)
+}
+
+func TestMCPClientConfig_AggregateExplicitFields(t *testing.T) {
+	input := `{
+		"type": "aggregate",
+		"transportType": "streamable-http",
+		"servers": ["postgres"],
+		"discovery": {
+			"timeout": "30s",
+			"cacheTtl": "5m"
+		}
+	}`
+
+	var cfg MCPClientConfig
+	err := json.Unmarshal([]byte(input), &cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, ServerTypeAggregate, cfg.Type)
+	assert.Equal(t, MCPClientTypeStreamable, cfg.TransportType)
+	assert.Equal(t, []string{"postgres"}, cfg.Servers)
+	require.NotNil(t, cfg.Discovery)
+	assert.Equal(t, 30*time.Second, cfg.Discovery.Timeout)
+	assert.Equal(t, 5*time.Minute, cfg.Discovery.CacheTTL)
+}
+
+func TestMCPClientConfig_AggregateInvalidDiscoveryDurations(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError string
+	}{
+		{
+			name: "zero_timeout",
+			input: `{
+				"type": "aggregate",
+				"discovery": {"timeout": "0s", "cacheTtl": "60s"}
+			}`,
+			expectError: "discovery timeout must be positive",
+		},
+		{
+			name: "negative_timeout",
+			input: `{
+				"type": "aggregate",
+				"discovery": {"timeout": "-1s", "cacheTtl": "60s"}
+			}`,
+			expectError: "discovery timeout must be positive",
+		},
+		{
+			name: "zero_cache_ttl",
+			input: `{
+				"type": "aggregate",
+				"discovery": {"timeout": "10s", "cacheTtl": "0s"}
+			}`,
+			expectError: "discovery cacheTtl must be positive",
+		},
+		{
+			name: "negative_cache_ttl",
+			input: `{
+				"type": "aggregate",
+				"discovery": {"timeout": "10s", "cacheTtl": "-5m"}
+			}`,
+			expectError: "discovery cacheTtl must be positive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg MCPClientConfig
+			err := json.Unmarshal([]byte(tt.input), &cfg)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+func TestMCPClientConfig_DirectTypeDefault(t *testing.T) {
+	os.Setenv("TEST_URL", "http://localhost:5432")
+	defer os.Unsetenv("TEST_URL")
+
+	input := `{
+		"transportType": "sse",
+		"url": "http://localhost:5432"
+	}`
+
+	var cfg MCPClientConfig
+	err := json.Unmarshal([]byte(input), &cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, ServerTypeDirect, cfg.Type)
+	assert.False(t, cfg.IsAggregate())
+}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -255,6 +255,17 @@ func validateServersStructure(rawConfig map[string]any, result *ValidationResult
 		}
 	}
 
+	aggregateNames := make(map[string]bool)
+	for name, server := range servers {
+		srv, ok := server.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, ok := srv["type"].(string); ok && t == "aggregate" {
+			aggregateNames[name] = true
+		}
+	}
+
 	for name, server := range servers {
 		srv, ok := server.(map[string]any)
 		if !ok {
@@ -262,6 +273,19 @@ func validateServersStructure(rawConfig map[string]any, result *ValidationResult
 				Path:    fmt.Sprintf("mcpServers.%s", name),
 				Message: "server must be an object",
 			})
+			continue
+		}
+
+		if !isValidServerName(name) {
+			result.Errors = append(result.Errors, ValidationError{
+				Path:    fmt.Sprintf("mcpServers.%s", name),
+				Message: "server name is invalid (must start with alphanumeric, then alphanumeric/underscore/hyphen only)",
+			})
+		}
+
+		serverType, _ := srv["type"].(string)
+		if serverType == "aggregate" {
+			validateAggregateServerStructure(name, srv, servers, aggregateNames, result)
 			continue
 		}
 
@@ -330,6 +354,158 @@ func validateServersStructure(rawConfig map[string]any, result *ValidationResult
 				requiresUserToken = requiresToken
 			}
 			validateServiceAuths(serviceAuths, name, requiresUserToken, result)
+		}
+
+		// Check tool filter configuration
+		if options, ok := srv["options"].(map[string]any); ok {
+			if toolFilter, ok := options["toolFilter"].(map[string]any); ok {
+				validateToolFilterStructure(toolFilter, fmt.Sprintf("mcpServers.%s.options.toolFilter", name), result)
+			}
+		}
+	}
+}
+
+func validateToolFilterStructure(filter map[string]any, path string, result *ValidationResult) {
+	mode, hasMode := filter["mode"].(string)
+	list, hasList := filter["list"].([]any)
+
+	if hasList && len(list) > 0 && !hasMode {
+		result.Errors = append(result.Errors, ValidationError{
+			Path:    path + ".mode",
+			Message: "mode is required when list is provided (must be 'allow' or 'block')",
+		})
+	}
+	if hasMode && mode != "allow" && mode != "block" {
+		result.Errors = append(result.Errors, ValidationError{
+			Path:    path + ".mode",
+			Message: fmt.Sprintf("invalid mode '%s' (must be 'allow' or 'block')", mode),
+		})
+	}
+}
+
+// validateAggregateServerStructure checks aggregate server configuration
+func validateAggregateServerStructure(name string, srv map[string]any, allServers map[string]any, aggregateNames map[string]bool, result *ValidationResult) {
+	path := fmt.Sprintf("mcpServers.%s", name)
+
+	// Reject direct-only fields
+	directOnlyFields := []string{"command", "args", "env", "url", "headers", "timeout", "inline", "requiresUserToken", "userAuthentication"}
+	for _, field := range directOnlyFields {
+		if _, ok := srv[field]; ok {
+			result.Errors = append(result.Errors, ValidationError{
+				Path:    path + "." + field,
+				Message: fmt.Sprintf("%s is not allowed on aggregate servers", field),
+			})
+		}
+	}
+
+	// Validate transportType if present
+	if tt, ok := srv["transportType"].(string); ok {
+		if tt != "sse" && tt != "streamable-http" {
+			result.Errors = append(result.Errors, ValidationError{
+				Path:    path + ".transportType",
+				Message: "aggregate servers only support 'sse' or 'streamable-http' transport",
+			})
+		}
+	}
+
+	// Validate servers references
+	if serversList, ok := srv["servers"].([]any); ok {
+		seenRefs := make(map[string]bool, len(serversList))
+		for i, s := range serversList {
+			ref, ok := s.(string)
+			if !ok {
+				result.Errors = append(result.Errors, ValidationError{
+					Path:    fmt.Sprintf("%s.servers[%d]", path, i),
+					Message: "server reference must be a string",
+				})
+				continue
+			}
+			if seenRefs[ref] {
+				result.Errors = append(result.Errors, ValidationError{
+					Path:    fmt.Sprintf("%s.servers[%d]", path, i),
+					Message: fmt.Sprintf("duplicate server reference '%s'", ref),
+				})
+				continue
+			}
+			seenRefs[ref] = true
+			if ref == name {
+				result.Errors = append(result.Errors, ValidationError{
+					Path:    fmt.Sprintf("%s.servers[%d]", path, i),
+					Message: "aggregate cannot reference itself",
+				})
+				continue
+			}
+			if aggregateNames[ref] {
+				result.Errors = append(result.Errors, ValidationError{
+					Path:    fmt.Sprintf("%s.servers[%d]", path, i),
+					Message: fmt.Sprintf("aggregate cannot reference another aggregate '%s'", ref),
+				})
+				continue
+			}
+			refServer, exists := allServers[ref]
+			if !exists {
+				result.Errors = append(result.Errors, ValidationError{
+					Path:    fmt.Sprintf("%s.servers[%d]", path, i),
+					Message: fmt.Sprintf("server '%s' does not exist", ref),
+				})
+				continue
+			}
+			if refSrv, ok := refServer.(map[string]any); ok {
+				if tt, ok := refSrv["transportType"].(string); ok && tt == "inline" {
+					result.Errors = append(result.Errors, ValidationError{
+						Path:    fmt.Sprintf("%s.servers[%d]", path, i),
+						Message: fmt.Sprintf("aggregate cannot reference inline server '%s' (inline servers have no network transport)", ref),
+					})
+				}
+			}
+		}
+	}
+
+	// Validate discovery config durations
+	if discovery, ok := srv["discovery"].(map[string]any); ok {
+		validateDiscoveryDurations(discovery, path+".discovery", result)
+	}
+}
+
+func validateDiscoveryDurations(discovery map[string]any, path string, result *ValidationResult) {
+	checkPositiveDuration := func(field string) {
+		if val, ok := discovery[field].(string); ok && val != "" {
+			d, err := time.ParseDuration(val)
+			if err != nil {
+				result.Errors = append(result.Errors, ValidationError{
+					Path:    path + "." + field,
+					Message: fmt.Sprintf("invalid duration '%s': %v", val, err),
+				})
+			} else if d <= 0 {
+				result.Errors = append(result.Errors, ValidationError{
+					Path:    path + "." + field,
+					Message: fmt.Sprintf("%s must be positive, got %s", field, val),
+				})
+			}
+		}
+	}
+	checkPositiveDuration("timeout")
+	checkPositiveDuration("cacheTtl")
+
+	if maxConns, ok := discovery["maxConnsPerUser"].(float64); ok {
+		if maxConns < 0 {
+			result.Errors = append(result.Errors, ValidationError{
+				Path:    path + ".maxConnsPerUser",
+				Message: "maxConnsPerUser cannot be negative",
+			})
+		}
+	}
+
+	timeoutStr, hasTimeout := discovery["timeout"].(string)
+	cacheTtlStr, hasCacheTtl := discovery["cacheTtl"].(string)
+	if hasTimeout && hasCacheTtl {
+		timeoutDur, err1 := time.ParseDuration(timeoutStr)
+		cacheTtlDur, err2 := time.ParseDuration(cacheTtlStr)
+		if err1 == nil && err2 == nil && timeoutDur >= cacheTtlDur {
+			result.Warnings = append(result.Warnings, ValidationError{
+				Path:    path,
+				Message: fmt.Sprintf("timeout (%s) >= cacheTtl (%s): discovery may not complete before cache expires", timeoutStr, cacheTtlStr),
+			})
 		}
 	}
 }

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -616,3 +616,275 @@ func TestValidateFile_ImprovedErrorMessages(t *testing.T) {
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }
+
+func TestValidateFile_AggregateServer(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     string
+		wantErrors []string
+	}{
+		{
+			name: "valid_aggregate",
+			config: `{
+				"version": "v0.0.1-DEV_EDITION",
+				"proxy": {
+					"baseURL": "http://localhost:8080",
+					"addr": ":8080"
+				},
+				"mcpServers": {
+					"postgres": {
+						"transportType": "stdio",
+						"command": "pg-mcp"
+					},
+					"mcp": {
+						"type": "aggregate",
+						"servers": ["postgres"]
+					}
+				}
+			}`,
+			wantErrors: nil,
+		},
+		{
+			name: "server_name_with_dot",
+			config: `{
+				"version": "v0.0.1-DEV_EDITION",
+				"proxy": {
+					"baseURL": "http://localhost:8080",
+					"addr": ":8080"
+				},
+				"mcpServers": {
+					"my.server": {
+						"transportType": "stdio",
+						"command": "test"
+					}
+				}
+			}`,
+			wantErrors: []string{"is invalid"},
+		},
+		{
+			name: "aggregate_rejects_direct_fields",
+			config: `{
+				"version": "v0.0.1-DEV_EDITION",
+				"proxy": {
+					"baseURL": "http://localhost:8080",
+					"addr": ":8080"
+				},
+				"mcpServers": {
+					"mcp": {
+						"type": "aggregate",
+						"command": "test",
+						"args": ["--flag"],
+						"env": {"FOO": "bar"},
+						"url": "http://localhost",
+						"headers": {"X-Key": "val"},
+						"timeout": "5s"
+					}
+				}
+			}`,
+			wantErrors: []string{
+				"command is not allowed on aggregate",
+				"args is not allowed on aggregate",
+				"env is not allowed on aggregate",
+				"url is not allowed on aggregate",
+				"headers is not allowed on aggregate",
+				"timeout is not allowed on aggregate",
+			},
+		},
+		{
+			name: "aggregate_self_reference",
+			config: `{
+				"version": "v0.0.1-DEV_EDITION",
+				"proxy": {
+					"baseURL": "http://localhost:8080",
+					"addr": ":8080"
+				},
+				"mcpServers": {
+					"mcp": {
+						"type": "aggregate",
+						"servers": ["mcp"]
+					}
+				}
+			}`,
+			wantErrors: []string{"cannot reference itself"},
+		},
+		{
+			name: "aggregate_references_other_aggregate",
+			config: `{
+				"version": "v0.0.1-DEV_EDITION",
+				"proxy": {
+					"baseURL": "http://localhost:8080",
+					"addr": ":8080"
+				},
+				"mcpServers": {
+					"agg1": {
+						"type": "aggregate"
+					},
+					"agg2": {
+						"type": "aggregate",
+						"servers": ["agg1"]
+					}
+				}
+			}`,
+			wantErrors: []string{"cannot reference another aggregate"},
+		},
+		{
+			name: "aggregate_references_nonexistent",
+			config: `{
+				"version": "v0.0.1-DEV_EDITION",
+				"proxy": {
+					"baseURL": "http://localhost:8080",
+					"addr": ":8080"
+				},
+				"mcpServers": {
+					"mcp": {
+						"type": "aggregate",
+						"servers": ["nonexistent"]
+					}
+				}
+			}`,
+			wantErrors: []string{"does not exist"},
+		},
+		{
+			name: "aggregate_references_inline",
+			config: `{
+				"version": "v0.0.1-DEV_EDITION",
+				"proxy": {
+					"baseURL": "http://localhost:8080",
+					"addr": ":8080"
+				},
+				"mcpServers": {
+					"tools": {
+						"transportType": "inline",
+						"inline": {"tools": []}
+					},
+					"mcp": {
+						"type": "aggregate",
+						"servers": ["tools"]
+					}
+				}
+			}`,
+			wantErrors: []string{"cannot reference inline server"},
+		},
+		{
+			name: "aggregate_invalid_transport",
+			config: `{
+				"version": "v0.0.1-DEV_EDITION",
+				"proxy": {
+					"baseURL": "http://localhost:8080",
+					"addr": ":8080"
+				},
+				"mcpServers": {
+					"mcp": {
+						"type": "aggregate",
+						"transportType": "stdio"
+					}
+				}
+			}`,
+			wantErrors: []string{"only support 'sse' or 'streamable-http'"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile := filepath.Join(t.TempDir(), "config.json")
+			require.NoError(t, os.WriteFile(tmpFile, []byte(tt.config), 0644))
+
+			result, err := ValidateFile(tmpFile)
+			require.NoError(t, err)
+
+			if tt.wantErrors == nil {
+				assert.True(t, result.IsValid(), "Expected no errors, got: %v", result.Errors)
+			} else {
+				for _, wantErr := range tt.wantErrors {
+					found := false
+					for _, gotErr := range result.Errors {
+						if strings.Contains(gotErr.Message, wantErr) {
+							found = true
+							break
+						}
+					}
+					assert.True(t, found, "Expected error containing '%s', got: %v", wantErr, result.Errors)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateFile_ToolFilterMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     string
+		wantErrors []string
+	}{
+		{
+			name: "valid_tool_filter",
+			config: `{
+				"version": "v0.0.1-DEV_EDITION",
+				"proxy": {"baseURL": "http://localhost:8080", "addr": ":8080"},
+				"mcpServers": {
+					"postgres": {
+						"transportType": "sse",
+						"url": "http://localhost:5432",
+						"options": {"toolFilter": {"mode": "block", "list": ["drop"]}}
+					}
+				}
+			}`,
+			wantErrors: nil,
+		},
+		{
+			name: "invalid_tool_filter_mode",
+			config: `{
+				"version": "v0.0.1-DEV_EDITION",
+				"proxy": {"baseURL": "http://localhost:8080", "addr": ":8080"},
+				"mcpServers": {
+					"postgres": {
+						"transportType": "sse",
+						"url": "http://localhost:5432",
+						"options": {"toolFilter": {"mode": "allowlist", "list": ["query"]}}
+					}
+				}
+			}`,
+			wantErrors: []string{"invalid mode 'allowlist'"},
+		},
+		{
+			name: "tool_filter_list_without_mode",
+			config: `{
+				"version": "v0.0.1-DEV_EDITION",
+				"proxy": {"baseURL": "http://localhost:8080", "addr": ":8080"},
+				"mcpServers": {
+					"postgres": {
+						"transportType": "sse",
+						"url": "http://localhost:5432",
+						"options": {"toolFilter": {"list": ["query"]}}
+					}
+				}
+			}`,
+			wantErrors: []string{"mode is required when list is provided"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile := filepath.Join(t.TempDir(), "config.json")
+			require.NoError(t, os.WriteFile(tmpFile, []byte(tt.config), 0644))
+
+			result, err := ValidateFile(tmpFile)
+			require.NoError(t, err)
+
+			if tt.wantErrors == nil {
+				assert.True(t, result.IsValid(), "Expected no errors, got: %v", result.Errors)
+			} else {
+				for _, wantErr := range tt.wantErrors {
+					found := false
+					for _, gotErr := range result.Errors {
+						if strings.Contains(gotErr.Message, wantErr) {
+							found = true
+							break
+						}
+					}
+					assert.True(t, found, "Expected error containing '%s', got: %v", wantErr, result.Errors)
+				}
+			}
+		})
+	}
+}

--- a/internal/mcpfront.go
+++ b/internal/mcpfront.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -10,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dgellow/mcp-front/internal/aggregate"
 	"github.com/dgellow/mcp-front/internal/auth"
 	"github.com/dgellow/mcp-front/internal/client"
 	"github.com/dgellow/mcp-front/internal/config"
@@ -28,6 +30,7 @@ type MCPFront struct {
 	config         config.Config
 	httpServer     *server.HTTPServer
 	sessionManager *client.StdioSessionManager
+	aggregates     []*aggregate.Server
 	storage        storage.Storage
 }
 
@@ -77,6 +80,7 @@ func NewMCPFront(ctx context.Context, cfg config.Config) (*MCPFront, error) {
 		client.WithMaxPerUser(maxPerUser),
 		client.WithCleanupInterval(cleanupInterval),
 	)
+	sessionManager.Start()
 
 	userTokenService := server.NewUserTokenService(store, serviceOAuthClient)
 
@@ -85,7 +89,7 @@ func NewMCPFront(ctx context.Context, cfg config.Config) (*MCPFront, error) {
 		Version: "dev",
 	}
 
-	mux, err := buildHTTPHandler(
+	mux, aggregates, err := buildHTTPHandler(
 		cfg,
 		store,
 		authServer,
@@ -108,6 +112,7 @@ func NewMCPFront(ctx context.Context, cfg config.Config) (*MCPFront, error) {
 		config:         cfg,
 		httpServer:     httpServer,
 		sessionManager: sessionManager,
+		aggregates:     aggregates,
 		storage:        store,
 	}, nil
 }
@@ -155,11 +160,22 @@ func (m *MCPFront) Run() error {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer shutdownCancel()
 
+	var shutdownErrors []error
+
 	if err := m.httpServer.Stop(shutdownCtx); err != nil {
 		log.LogErrorWithFields("mcpfront", "HTTP server shutdown error", map[string]any{
 			"error": err.Error(),
 		})
-		return err
+		shutdownErrors = append(shutdownErrors, err)
+	}
+
+	for _, agg := range m.aggregates {
+		if err := agg.Shutdown(shutdownCtx); err != nil {
+			log.LogWarnWithFields("mcpfront", "Aggregate server shutdown error", map[string]any{
+				"error": err.Error(),
+			})
+			shutdownErrors = append(shutdownErrors, err)
+		}
 	}
 
 	if m.sessionManager != nil {
@@ -169,7 +185,7 @@ func (m *MCPFront) Run() error {
 	log.LogInfoWithFields("mcpfront", "Application shutdown complete", map[string]any{
 		"reason": shutdownReason,
 	})
-	return nil
+	return errors.Join(shutdownErrors...)
 }
 
 func setupStorage(ctx context.Context, cfg config.Config) (storage.Storage, error) {
@@ -265,7 +281,7 @@ func buildHTTPHandler(
 	userTokenService *server.UserTokenService,
 	baseURL string,
 	info mcp.Implementation,
-) (http.Handler, error) {
+) (http.Handler, []*aggregate.Server, error) {
 	mux := http.NewServeMux()
 	basePath := cfg.Proxy.BasePath
 
@@ -340,8 +356,13 @@ func buildHTTPHandler(
 	}
 
 	sseServers := make(map[string]*mcpserver.SSEServer)
+	var aggregates []*aggregate.Server
 
 	for serverName, serverConfig := range cfg.MCPServers {
+		if serverConfig.IsAggregate() {
+			continue
+		}
+
 		log.LogInfoWithFields("server", "Registering MCP server", map[string]any{
 			"name":                serverName,
 			"transport_type":      serverConfig.TransportType,
@@ -350,19 +371,19 @@ func buildHTTPHandler(
 
 		var handler http.Handler
 		var err error
-		var mcpServer *mcpserver.MCPServer
+		var mcpSrv *mcpserver.MCPServer
 		var sseServer *mcpserver.SSEServer
 
 		if serverConfig.TransportType == config.MCPClientTypeInline {
 			handler, err = buildInlineHandler(serverName, serverConfig)
 			if err != nil {
-				return nil, fmt.Errorf("failed to create inline handler for %s: %w", serverName, err)
+				return nil, nil, fmt.Errorf("failed to create inline handler for %s: %w", serverName, err)
 			}
 		} else {
 			if serverConfig.IsStdio() {
-				sseServer, mcpServer, err = buildStdioSSEServer(serverName, baseURL, sessionManager)
+				sseServer, mcpSrv, err = buildStdioSSEServer(serverName, baseURL, sessionManager)
 				if err != nil {
-					return nil, fmt.Errorf("failed to create SSE server for %s: %w", serverName, err)
+					return nil, nil, fmt.Errorf("failed to create SSE server for %s: %w", serverName, err)
 				}
 				sseServers[serverName] = sseServer
 			}
@@ -375,7 +396,7 @@ func buildHTTPHandler(
 				info,
 				sessionManager,
 				sseServers[serverName],
-				mcpServer,
+				mcpSrv,
 				userTokenService.GetUserToken,
 			)
 		}
@@ -398,8 +419,50 @@ func buildHTTPHandler(
 		mux.Handle(route("/"+serverName+"/"), server.ChainMiddleware(handler, mcpMiddlewares...))
 	}
 
+	for serverName, serverConfig := range cfg.MCPServers {
+		if !serverConfig.IsAggregate() {
+			continue
+		}
+
+		backendConfigs := make(map[string]*config.MCPClientConfig, len(serverConfig.Servers))
+		for _, ref := range serverConfig.Servers {
+			backendConfigs[ref] = cfg.MCPServers[ref]
+		}
+
+		agg := aggregate.NewServer(aggregate.ServerConfig{
+			Name:            serverName,
+			TransportType:   serverConfig.TransportType,
+			Backends:        backendConfigs,
+			Discovery:       serverConfig.Discovery,
+			GetUserToken:    userTokenService.GetUserToken,
+			CreateTransport: client.DefaultTransportCreator,
+			BaseURL:         baseURL,
+		})
+		agg.Start()
+		aggregates = append(aggregates, agg)
+
+		aggMiddlewares := []server.MiddlewareFunc{
+			mcpLogger,
+			corsMiddleware,
+		}
+		if authServer != nil {
+			aggMiddlewares = append(aggMiddlewares, oauth.NewValidateTokenMiddleware(authServer, authConfig.Issuer, authConfig.DangerouslyAcceptIssuerAudience))
+		}
+		if len(serverConfig.ServiceAuths) > 0 {
+			aggMiddlewares = append(aggMiddlewares, server.NewServiceAuthMiddleware(serverConfig.ServiceAuths))
+		}
+		aggMiddlewares = append(aggMiddlewares, mcpRecover)
+
+		mux.Handle(route("/"+serverName+"/"), server.ChainMiddleware(agg.Handler(), aggMiddlewares...))
+
+		log.LogInfoWithFields("server", "Registered aggregate MCP server", map[string]any{
+			"name":     serverName,
+			"backends": serverConfig.Servers,
+		})
+	}
+
 	log.LogInfoWithFields("server", "MCP proxy server initialized", nil)
-	return mux, nil
+	return mux, aggregates, nil
 }
 
 func buildInlineHandler(serverName string, serverConfig *config.MCPClientConfig) (http.Handler, error) {


### PR DESCRIPTION
## Summary

<img width="441" height="478" alt="image" src="https://github.com/user-attachments/assets/142ceb3b-be9f-40ea-8d7c-81061573bd1c" />



mcp-front currently exposes each backend as a separate MCP server with its own endpoint, its own OAuth token, and its own SSE connection. This is correct from a security standpoint (per-service audience isolation per RFC 8707), but the authentication experience scales poorly. Every service requires a separate login flow. When all your internal MCP servers share the same Google Workspace identity, authenticating eight times to prove you're the same person is painful. Session drops mean re-authenticating eight times. The friction grows linearly with the number of services.

The MCP protocol has no concept of shared identity across servers. Each server is independent. The only way to solve this is to stop exposing N separate servers and instead expose one. This PR adds a new `"aggregate"` server type that combines multiple backends into a single MCP endpoint. One connection, one token, all tools.

An aggregate server acts as an MCP server to the client and an MCP client to every backend it includes. Tools are namespaced by service name (`postgres.query`, `linear.create_issue`) so routing is unambiguous. When the client calls a tool, the aggregate strips the prefix, routes to the correct backend, and returns the result. Each authenticated user gets their own set of backend connections with proper token isolation.

The aggregate type is opt-in. Per-service endpoints continue to work exactly as before. See `docs/aggregated-mcp-endpoint.md` for the full design document including configuration, connection lifecycle, and scoping decisions.

This PR also fixes the mock SSE and streamable servers in the integration test fixtures to speak proper MCP protocol (correct SSE endpoint events, initialize handler, standard content response format), and adds integration tests covering tool discovery, cross-backend tool calls, partial backend failure, and tool filtering.

## Test plan

Integration tests added in `integration/aggregate_test.go` covering basic discovery and tool calls across SSE and streamable backends, partial failure when a backend is unreachable, and tool filtering via block lists. Existing SSE and streamable integration tests updated and passing.